### PR TITLE
Add ocp_release_image to vars file

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -1,7 +1,3 @@
-# To set a specific release to install, add the argument:
-#   -e ocp_release_image=quay.io/openshift-release-dev/ocp-release:4.5.3-x86_64
-# TODO: parameterise the above
-
 default: \
   ocp_install \
   olm \

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -3,6 +3,10 @@ base_path: /home/ocp
 #dev_scripts_repo: defaults to "https://github.com/openshift-metal3/dev-scripts.git"
 #dev_scripts_branch: defaults to "HEAD"
 
+# To set a specific release to install. Default is to use the get_cnv_tested_ocp_version
+# role to detect OCP version tested for CNV
+#ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.5.3-x86_64
+
 # private repo to read required secret files from
 # The playbooks expect secret files which can be placed in a private repo
 # Right now these are:


### PR DESCRIPTION
Setting ocp_release_image allows to overwrite the auto detected
image version. This can be set in defaults.yaml .