### PR TITLE
Read required secret files from git repo

### DIFF
--- a/ansible/01_prepare_host.yaml
+++ b/ansible/01_prepare_host.yaml
@@ -29,7 +29,9 @@
       vars:
         rhos_release_args: "-x"
 
-    - block:
+    - name: use local rhel-subscription info
+      when: secrets_repo is undefined
+      block:
       - name: Include rhel-subscription info
         include_vars: vars/rhel-subscription.yaml
       rescue:
@@ -37,6 +39,32 @@
           msg: |
             vars/rhel-subscription.yaml is not present. You must create this
             file manually. The format of the file is:
+
+            rhel_subscription_activation_key: <activation key>
+            rhel_subscription_org_id: "xxxxxxx"
+
+    - name: use secrets_repo
+      when: secrets_repo is defined
+      block:
+      - set_fact:
+          secrets_repo_path: "{{ ansible_env.HOME }}/{{ secrets_repo | urlsplit('hostname') }}/{{ (secrets_repo | urlsplit('path') | splitext)[0] }}"
+      - name: create base dir for secrets_repo repo
+        file:
+          path: "{{ secrets_repo_path }}"
+          state: directory
+          mode: "0755"
+      - name: Clone the repo specified in secrets_repo
+        git:
+          repo: "{{ secrets_repo }}"
+          dest: "{{ secrets_repo_path }}"
+          version: "{{ secrets_branch | default('HEAD', true) }}"
+      - name: Include rhel-subscription info
+        include_vars: "{{ secrets_repo_path }}/rhel-subscription.yaml"
+      rescue:
+      - fail:
+          msg: |
+            rhel-subscription.yaml is not present in {{ secrets_repo }}. You must create this
+            file. The format of the file is:
 
             rhel_subscription_activation_key: <activation key>
             rhel_subscription_org_id: "xxxxxxx"

--- a/ansible/03_ocp_dev_scripts.yaml
+++ b/ansible/03_ocp_dev_scripts.yaml
@@ -56,7 +56,11 @@
       regexp: '^export WORKING_DIR='
       line: export WORKING_DIR='{{ base_path }}'
 
-  - block:
+  - name: Copy pull-secret file 
+    when: secrets_repo is undefined
+    block:
+    - set_fact:
+        secrets_repo_path: "{{ base_path }}"
     - name: Copy pull-secret
       copy:
         dest: "{{ base_path }}/pull-secret"
@@ -68,11 +72,27 @@
           https://cloud.redhat.com/openshift/install/pull-secret and copy it
           there manually.
 
+  - name: use secrets_repo
+    when: secrets_repo is defined
+    block:
+    - set_fact:
+        secrets_repo_path: "{{ base_path }}/{{ secrets_repo | urlsplit('hostname') }}/{{ (secrets_repo | urlsplit('path') | splitext)[0] }}"
+    - name: create base dir for secrets_repo repo
+      file:
+        path: "{{ secrets_repo_path }}"
+        state: directory
+        mode: "0755"
+    - name: Clone the repo specified in secrets_repo
+      git:
+        repo: "{{ secrets_repo }}"
+        dest: "{{ secrets_repo_path }}"
+        version: "{{ secrets_branch | default('HEAD', true) }}"
+
   - name: set PULL_SECRET in {{ base_path }}/dev-scripts/config_$USER.sh
     lineinfile:
       path: "{{ base_path }}/dev-scripts/config_$USER.sh"
       regexp: '^export PULL_SECRET='
-      line: export PULL_SECRET=$(cat "{{ base_path }}/pull-secret")
+      line: export PULL_SECRET=$(cat "{{ secrets_repo_path }}/pull-secret")
 
   - name: set IP_STACK in {{ base_path }}/dev-scripts/config_$USER.sh
     lineinfile:

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -70,7 +70,7 @@ get root priviledges to the host via passwordless sudo.
 ```
 ssh root@<beaker node>
 dnf install -y git
-git -c http.sslVerify=false clone https://gitlab.cee.redhat.com/mschuppe/openstack-k8s.git
+git clone git@github.com:openstack-k8s-operators/dev-tools.git
 ```
 
 ##### Install Ansible
@@ -93,7 +93,7 @@ There is a Makefile which runs all the steps per default
 
 ```
 dnf install -y make
-cd openstack-k8s/ansible
+cd dev-scripts/ansible
 make
 ```
 

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -2,8 +2,17 @@
 base_path: /home/ocp
 #dev_scripts_repo: defaults to "https://github.com/openshift-metal3/dev-scripts.git"
 #dev_scripts_branch: defaults to "HEAD"
-#dev_scripts_repo: "https://github.com/stuggi/dev-scripts.git"
-#dev_scripts_branch: "masters_schedulable"
+
+# private repo to read required secret files from
+# The playbooks expect secret files which can be placed in a private repo
+# Right now these are:
+# * rhel-subscription.yaml - content:
+#   rhel_subscription_activation_key: <activation key>
+#   rhel_subscription_org_id: "xxxxxxx"
+# * pull-secret
+#   obtain it from https://cloud.redhat.com/openshift/install/pull-secret
+#secrets_repo: https uri to repo, no default manual local file is expected if not present
+#secrets_branch: defaults to "HEAD"
 
 # dev scripts switched to ipv6 per default, for now switch back
 # https://github.com/openshift-metal3/dev-scripts/pull/969


### PR DESCRIPTION
This adds secrets_repo/secrets_branch parameters to default.yaml
which allows to read required secret files from a git repo.

secrets_repo: https uri to repo, no default manual local file is expected if not present
secrets_branch: defaults to "HEAD"

(cherry picked from commit a49b3605e9c794a6350db9b5ee57e6e604f81cf5)