### PR TITLE
Ensure local-defaults.yaml is proper syntax

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -10,7 +10,7 @@ hosts:
 	echo -e "localhost ansible_connection=local\n\n[convergence_base]\nlocalhost" > $@
 
 local-defaults.yaml:
-	touch $@
+	echo -e "vars:" > $@
 
 local-deps:
 	ansible-galaxy install -r requirements.yml


### PR DESCRIPTION
Ansible expects file with local defaults to be
a valid JSON format, otherwise it will fail.