### PR TITLE
Set pipefail option when running dev-scripts

### DIFF
--- a/ansible/03_ocp_dev_scripts.yaml
+++ b/ansible/03_ocp_dev_scripts.yaml
@@ -150,6 +150,7 @@
 
   - name: run dev-script
     shell: |
+      set -o pipefail
       export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
       make 2>&1 | tee ~/dev-script.log
     args:


### PR DESCRIPTION
The pipefail option should be set in the shell since the ansible task
pipes the dev-scripts output to tee. Without the option set, dev-scripts
could fail and the ansible task would still succeed.