### PR TITLE
Decrease the OCP registry PVC size

### DIFF
--- a/ansible/files/openshift-image-registry-pvc.yaml
+++ b/ansible/files/openshift-image-registry-pvc.yaml
@@ -8,4 +8,4 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 100Gi 
+      storage: 10Gi 


### PR DESCRIPTION
100G was way to large. This sets it to 10G.