### PR TITLE
Fixes for osp machineset setup

### DIFF
--- a/ansible/12_setup_worker_osp_machineset.yaml
+++ b/ansible/12_setup_worker_osp_machineset.yaml
@@ -94,7 +94,7 @@
       environment:
         PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
         KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
-      loop: "{{ range(0, worker_replicas , 1)|list }}"
+      loop: "{{ range(0, replicas , 1)|list }}"
 
     - name: scale up osp worker nodes by {{ osp_compute_scale }}
       become_user: ocp

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -84,3 +84,6 @@ local_working_dir: "~/{{ ocp_cluster_name }}-working"
 # nfs export directory
 nfs_data_dir: /home/nfs/data
 nfs_export_dir: /home/nfs
+
+# number of OCP worker nodes should be OSP compute hosts
+osp_compute_scale: 1


### PR DESCRIPTION
osp_compute_scale is still a required variable and must be set as it is
assumed by 12_setup_worker_osp_machineset.yaml.

Also fixes an incorrect usage of worker_replicas.