### PR TITLE
Wait for the image registry creation before deployment

### DIFF
--- a/ansible/ocp_image_registry.yaml
+++ b/ansible/ocp_image_registry.yaml
@@ -41,9 +41,25 @@
       # configure storage pvc for openshift-image-registry
       oc patch configs.imageregistry.operator.openshift.io/cluster --type merge \
           --patch '{"spec":{"storage":{"pvc":{"claim": "openshift-image-registry-pvc"}}}}'
+    environment:
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
 
-      # wait for image registry to be deployed
-      oc wait --for condition=available -n openshift-image-registry deployment/image-registry --timeout=60s
+  - name: wait for deployment to be created
+    shell: |
+      oc get -n openshift-image-registry deployment/image-registry
+    environment:
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+    register: image_registry_deployment
+    until: image_registry_deployment is not failed
+    retries: 20
+    delay: 5
+
+  - name: wait for image registry to be deployed
+    shell: |
+      set -e
+      oc wait --for condition=available -n openshift-image-registry deployment/image-registry --timeout=120s
     environment:
       PATH: "{{ oc_env_path }}"
       KUBECONFIG: "{{ kubeconfig }}"


### PR DESCRIPTION
Adds wait for the image registry deployment to be created
before oc wait command for the registry to be deployed.

Without this the wait condition was not met as it was
race with creation.