### PR TITLE
Enhance NFS registry cleanup

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -64,10 +64,14 @@ olm_cleanup: hosts local-defaults.yaml
 # Unlike the ansible playbooks, the following all assume you're executing this
 # directly on the host.
 
-clean: ocp_cleanup host_cleanup
+clean: ocp_cleanup host_cleanup nfs_pvc_cleanup
 
 host_cleanup:
 	-echo | sudo tee /etc/exports
+
+nfs_pvc_cleanup:
+        -NFS_DATA_DIR=$$(grep nfs_data_dir ./vars/default.yaml |awk -F":" '{print $$2}') ;\
+        sudo su - root -c "find $$NFS_DATA_DIR -type d -name 'pv-*' -delete"
 
 ocp_cleanup:
 	-sudo su - ocp -c "cd dev-scripts && make clean"

--- a/ansible/files/openshift-image-registry-pvc.yaml
+++ b/ansible/files/openshift-image-registry-pvc.yaml
@@ -8,4 +8,5 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 10Gi 
+      storage: 10Gi
+  persistentVolumeReclaimPolicy: Delete


### PR DESCRIPTION
Adds Delete Reclaim policy to the image registry object.
Adds cleanup in the Makefile for removing pv- directories.