### PR TITLE
Revert change for the persistentVolumeReclaimPolicy

### DIFF
--- a/ansible/files/openshift-image-registry-pvc.yaml
+++ b/ansible/files/openshift-image-registry-pvc.yaml
@@ -9,4 +9,3 @@ spec:
   resources:
     requests:
       storage: 10Gi
-  persistentVolumeReclaimPolicy: Delete


### PR DESCRIPTION
The persistentVolumeReclaimPolicy should not be set to Delete.