### PR TITLE
Makefile: make deployment ordering dependencies explicit

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -46,26 +46,40 @@ osp_tests_run: hosts local-defaults.yaml
 	-i hosts -e @local-defaults.yaml \
   20_tempest_ocp.yaml \
 
-podified-ctlplane: hosts ctlplane
-ctlplane: local-defaults.yaml
-	# NOTE: requires 'make olm'
-	ANSIBLE_FORCE_COLOR=true ansible-playbook \
-	-i hosts -e @local-defaults.yaml \
-	install_namespace.yaml \
-	install_mariadb.yaml \
-	install_rabbitmq.yaml \
-	install_keystone.yaml \
-	install_glance.yaml \
-	install_placement.yaml \
-	install_ovn.yaml \
-	install_neutron-api.yaml \
-	install_nova-api.yaml \
-	install_nova-cell.yaml
+# Services which depend on olm
+olm_services=mariadb keystone glance
 
-olm: hosts local-defaults.yaml
+# Services which don't depend on olm
+yaml_services=rabbitmq ovn neutron-api nova-api nova-cell placement
+
+# Run a specific install playbook without dependencies
+install_%: install_%.yaml hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-i hosts -e @local-defaults.yaml $<
+
+# Run the install target for a playbook after running its dependencies
+_dep_%:
+	$(MAKE) install_$$(x="$@"; echo $${x#_dep_})
+
+_dep_olm=$(patsubst %,_dep_%,$(olm_services))
+_dep_yaml=$(patsubst %,_dep_%,$(yaml_services))
+_dep_all=$(_dep_olm) $(_dep_yaml)
+
+# Define deployment dependencies between control plane services
+$(_dep_all): install_namespace
+$(_dep_olm): olm
+_dep_keystone: _dep_mariadb _dep_rabbitmq
+_dep_glance _dep_neutron-api _dep_nova-api _dep_nova-cell _dep_placement: _dep_keystone
+_dep_neutron-api: _dep_ovn
+_dep_nova-api _dep_nova-cell: _dep_placement
+_dep_nova-cell: _dep_nova-api
+
+podified-ctlplane: ctlplane
+ctlplane: $(_dep_all)
+
+olm: hosts local-defaults.yaml install_namespace
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-v -i hosts -e @local-defaults.yaml \
-	install_namespace.yaml \
 	olm.yaml
 
 olm_cleanup: hosts local-defaults.yaml


### PR DESCRIPTION
This allows us to parallelise deployment of control plane services
with:

  make -j ctlplane

On my cluster this reduces deployment time from 7 to 4 minutes.

Note that a complete teardown and rebuild of the control plane can be done in under 10 minutes on my system:

$ oc delete ns/openstack # <- Yeah :) [1]
$ make olm_cleanup # Not sure this is required if we delete the ns
$ ... bump csv_version in local-defaults.yaml
$ make olm # About 2 minutes
$ sleep 60 # [2]
$ make -j ctlplane # About 4 minutes

[1] This leaves some PVs in a 'Failed' state with errors in the recycler. They go away eventually if you ignore them. No idea what this is about. There's no need to wait as a subsequent deployment will just use different PVs.

[2] Is this actually necessary? I haven't tested what happens if you start deploying before the operators exist. I guess it would be ok as long as the CRDs exist, but I'm pretty sure we'd be racing with the creation of those, too. We ought to workout a proper solution to this, as it's a potential production issue.