### PR TITLE
nfs: Schedule a daily fstrim on the virt host

### DIFF
--- a/ansible/05_default_storageclass.yaml
+++ b/ansible/05_default_storageclass.yaml
@@ -22,3 +22,9 @@
       group: host-nfs-storageclass
       storageclass_create: true
       storageclass_isdefault: true
+
+  - name: Schedule fstrim on the host
+    cron:
+      name: fstrim
+      special_time: daily
+      job: "/usr/sbin/fstrim -a"


### PR DESCRIPTION
We loopback mount thinly provisioned files for nfs exports. fstrim
will cause space to be reclaimed on the host filesystem after files
have been deleted from a PV.