### PR TITLE
Add target and playbook for osp cleanup

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -96,3 +96,8 @@ demo: hosts
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-i hosts -e @local-defaults.yaml \
 	demo.yaml
+
+osp_cleanup: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-v -i hosts -e @local-defaults.yaml \
+	osp_cleanup.yaml

--- a/ansible/osp_cleanup.yaml
+++ b/ansible/osp_cleanup.yaml
@@ -1,0 +1,25 @@
+#!/usr/bin/env ansible-playbook
+---
+- hosts: localhost
+  vars_files: "vars/default.yaml"
+
+  roles:
+  - oc_local
+
+  tasks:
+    - name: Cleanup of OpenStack
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+      block:
+        - name: switch to openstack project/namespace
+          shell: >
+            oc project openstack
+
+        - name: delete openstack.org CRD's
+          shell: >
+            oc get crds | grep openstack.org | cut -f1 -d ' ' | xargs -t oc delete crds --cascade
+
+        - name: delete openstack namespace
+          shell: >
+            oc delete namespace openstack


### PR DESCRIPTION
"make osp_cleanup" can be used to delete and cleanup all OpenStack
related resources from the ocp cluster.