### PR TITLE
Add job to create cell1 and enable auto discovery

### DIFF
--- a/ansible/files/ocp/nova-api/2/configmap.yaml
+++ b/ansible/files/ocp/nova-api/2/configmap.yaml
@@ -129,3 +129,7 @@ data:
     auth_url = http://keystone.openstack.svc:5000/
     username = placement
     password = foobar123
+
+    [scheduler]
+    # run periodic task to discover hosts automatically
+    discover_hosts_in_cells_interval = 60

--- a/ansible/files/ocp/nova-cell/3/create_cell1-job.yaml
+++ b/ansible/files/ocp/nova-cell/3/create_cell1-job.yaml
@@ -1,0 +1,53 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: &name nova-cell1-create-cell
+  namespace: &namespace openstack
+spec:
+  backoffLimit: 4
+  template:
+    metadata:
+      name: *name
+      namespace: *namespace
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: nova-api-kolla
+        env:
+        - name: KOLLA_CONFIG_STRATEGY
+          value: "COPY_ALWAYS"
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - mountPath: /var/lib/config-data
+            readOnly: true
+            name: config-data
+          - mountPath: /var/lib/kolla/config_files
+            readOnly: true
+            name: kolla-config
+        image: tripleotrain/rhel-binary-nova-api:current-tripleo
+        command:
+          - /bin/sh
+          - -c
+          - |
+            kolla_set_configs
+            nova-manage cell_v2 create_cell --name cell1 \
+                --database_connection "mysql+pymysql://nova-cell1:password@mariadb.openstack.svc/nova_cell1" \
+                --transport-url "rabbit://cell1:passw0rd@rabbitmq.openstack.svc:5672/cell1?ssl=0"
+      volumes:
+        - name: kolla-config
+          configMap:
+            name: nova-api
+            items:
+              - key: kolla-config-api.json
+                path: config.json
+        - name: config-data
+          configMap:
+            name: nova-api
+            defaultMode: 0444
+            items:
+              - key: nova.conf
+                path: nova.conf
+              - key: logging.conf
+                path: logging.conf


### PR DESCRIPTION
Add a job to create cell1. The transport_url and db connection
is hardcoded right now.

Also enable discover_hosts_in_cells_interval for the nova-scheduler
todo automatic periodic cell host discovery and no need to run
manual host discovery jobs when a compute node gets added.