### PR TITLE
Add openstackclient automation

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -68,6 +68,11 @@ olm: hosts local-defaults.yaml
 	install_namespace.yaml \
 	olm.yaml
 
+openstackclient: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-v -i hosts -e @local-defaults.yaml \
+	install_openstackclient.yaml \
+
 olm_cleanup: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-v -i hosts -e @local-defaults.yaml \

--- a/ansible/install_openstackclient.yaml
+++ b/ansible/install_openstackclient.yaml
@@ -1,0 +1,31 @@
+---
+- hosts: localhost
+  vars_files: "vars/default.yaml"
+  roles:
+  - oc_local
+
+  tasks:
+
+  - name: create openstackclient yamls dir
+    file:
+      path: "{{ working_dir }}/yamls/openstackclient"
+      state: directory
+
+  - name: create openstackclient-pod.yaml from template
+    vars:
+      os_password: foobar123
+      os_auth_url: http://keystone-openstack.apps.ostest.test.metalkube.org/
+    template:
+      src:  "openstackclient-pod.yaml.j2"
+      dest: "{{ working_dir }}/yamls/openstackclient/openstackclient-pod.yaml"
+      mode: 0644
+
+  - name: create openstackclient pod
+    become_user: ocp
+    shell: |
+      oc project openstack
+      oc delete --ignore-not-found pod openstackclient
+      oc apply -f {{ working_dir }}/yamls/openstackclient/openstackclient-pod.yaml
+    environment:
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"

--- a/ansible/templates/openstackclient-pod.yaml.j2
+++ b/ansible/templates/openstackclient-pod.yaml.j2
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: openstackclient
+  namespace: openstack
+spec:
+  metadata:
+    labels:
+      app: openstackclient
+  nodeSelector:
+    kubernetes.io/hostname: {{ openstackclient_pod_worker }}
+  containers:
+    - name: openstackclient
+      image: quay.io/openstack-k8s-operators/tripleo-deploy
+      command:
+        - sleep
+        - infinity
+      user: root
+      env:
+        - name: OS_USERNAME
+          value: admin
+        - name: NOVA_VERSION
+          value: "1.1"
+        - name: COMPUTE_API_VERSION
+          value: "1.1"
+        - name: OS_USERNAME
+          value: admin
+        - name: OS_PROJECT_NAME
+          value: admin
+        - name: OS_USER_DOMAIN_NAME
+          value: Default
+        - name: OS_PROJECT_DOMAIN_NAME
+          value: Default
+        - name: OS_NO_CACHE
+          value: "True"
+        - name: OS_CLOUDNAME
+          value: cnv
+        - name: PYTHONWARNINGS
+          value: 'ignore:Certificate has no, ignore:A true SSLContext object is not available'
+        - name: OS_AUTH_TYPE
+          value: password
+        - name: OS_PASSWORD
+          value: {{ os_password }}
+        - name: OS_AUTH_URL
+          value: {{ os_auth_url }}
+        - name: OS_IDENTITY_API_VERSION
+          value: "3"
+        - name: OS_COMPUTE_API_VERSION
+          value: "2.latest"
+        - name: OS_IMAGE_API_VERSION
+          value: "2"
+        - name: OS_VOLUME_API_VERSION
+          value: "3"
+        - name: OS_REGION_NAME
+          value: regionOne

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -84,3 +84,7 @@ nfs_data_dir: /home/nfs/data
 nfs_export_dir: /home/nfs
 
 default_timeout: 180
+
+# worker node where openstackclient pod will run
+openstackclient_pod_worker: worker-0
+


### PR DESCRIPTION
Add ansible automation and Makefile target to setup an openstackclient
pod that is automatically configured to talk to the deployed ctlplane.