### PR TITLE
Create required input to connect osp worker nodes to ctrl plane

### DIFF
--- a/ansible/09_create_common-config.yaml
+++ b/ansible/09_create_common-config.yaml
@@ -1,165 +1,131 @@
 ---
-- hosts: convergence_base
-  become: true
-  become_user: ocp
-
-  vars:
-    memcache_servers: ""
-    rabbit_transport_url: ""
+- hosts: localhost
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
 
   tasks:
-  - name: Include variables
-    include_vars: vars/default.yaml
+  - set_fact:
+      common_conf_dir: "{{ working_dir }}/common-conf"
+
+  - debug:
+      msg: "yamls will be written to {{ common_conf_dir }} locally"
 
   - name: check if common-config configmap already exist
-    shell: >
+    shell: |
+      set -e
       oc get configmap -n openstack | grep common-config
     register: common_config_exist
-    args:
-      chdir: "{{ base_path }}"
     environment:
-      PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-      KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
     ignore_errors: true
 
   - name: delete common-config configmap (reinstall/rerun)
     command: oc delete configmap common-config -n openstack
-    args:
-      chdir: "{{ base_path }}"
     environment:
-      PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-      KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
     when: common_config_exist.rc == 0
 
-  - name: Include OSP variables
-    include_vars:
-      file: "vars/{{ item }}"
-      name: "{{ item | regex_replace('.yaml$', '') }}"
-    with_items:
-      - osp_inventory.yaml
-      - osp_global_vars.yaml
-      - osp_global_config_settings.yaml
-      - osp_controller
-
-  - name: create comon-config configmap
+  - name: create common-config configmap
     block:
     - name: Create common-conf
       file:
-        path: "{{ base_path }}/common-conf"
+        path: "{{ common_conf_dir }}"
         state: directory
         mode: '0755'
 
-    - name: Add mappings to /etc/hosts
-      blockinfile:
-        path: "{{ base_path }}/common-conf/hosts"
-        create: yes
-        block: |
-          {{ osp_global_vars.hosts_entry }}
+    - name: create KeystoneAPI
+      shell: |
+        set -e
+        echo -n 'http://keystone.openstack.svc:5000/' > {{ common_conf_dir }}/keystoneAPI
 
-    - name: create publicVip
-      shell: >
-        echo -n {{ osp_global_vars.net_vip_map.external }} > {{ base_path }}/common-conf/publicVip
-
-    - name: create internalAPIVip
-      shell: >
-        echo -n {{ osp_global_vars.net_vip_map.internal_api }} > {{ base_path }}/common-conf/internalAPIVip
-
-    - name: get list of controller internal_api_ip
-      set_fact:
-        osp_controller_internal_api_ips: "{{ osp_controller_internal_api_ips|default([]) }} + [ '{{ item.value.internal_api_ip }}' ]"
-      loop: "{{ osp_inventory.Controller.hosts|dict2items }}"
-
-    - name: create memcache server string
-      set_fact:
-        memcache_servers: "{{ memcache_servers }}{{ (memcache_servers|length > 0) | ternary(',', '', omit) }}{{ item }}:11211"
-      with_items:
-        - "{{ osp_controller_internal_api_ips }}"
+    - name: create GlanceAPI
+      shell: |
+        set -e
+        echo -n 'http://glanceapi.openstack.svc:9292/' > {{ common_conf_dir }}/glanceAPI
 
     - name: create memcacheServers
-      shell: >
-        echo -n {{ memcache_servers }} > {{ base_path }}/common-conf/memcacheServers
+      shell: |
+        set -e
+        echo -n '' > {{ common_conf_dir }}/memcacheServers
+
+    - name: create hosts
+      shell: |
+        set -e
+        printf '# BEGIN ANSIBLE MANAGED BLOCK\n# END ANSIBLE MANAGED BLOCK' > {{ common_conf_dir }}/hosts
 
     - name: create config map
-      command: "oc create configmap common-config --from-file={{ base_path }}/common-conf/ -n openstack"
-      args:
-        chdir: "{{ base_path }}"
+      command: "oc create configmap common-config --from-file={{ common_conf_dir }}/ -n openstack"
       environment:
-        PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-        KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
-
-  - name: copy openstackclient-cm.yaml to {{ base_path }}
-    copy:
-      src: files/ocp/openstackclient-cm.yaml
-      dest: "{{ base_path }}/openstackclient-cm.yaml"
-      owner: ocp
-
-  - name: create openstackclient configMap
-    shell: >
-      oc apply -f {{ base_path }}/openstackclient-cm.yaml
-    args:
-      chdir: "{{ base_path }}"
-    environment:
-      PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-      KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
-
-  - name: copy openstackclient-admin-secret.yaml to {{ base_path }}
-    copy:
-      src: files/ocp/openstackclient-admin-secret.yaml
-      dest: "{{ base_path }}/openstackclient-admin-secret.yaml"
-      owner: ocp
-
-  - name: create openstackclient admin user secret
-    shell: >
-      oc apply -f {{ base_path }}/openstackclient-admin-secret.yaml
-    args:
-      chdir: "{{ base_path }}"
-    environment:
-      PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-      KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
-
-  - name: get list of controller internal_api_hostname
-    set_fact:
-      osp_controller_internal_api_hostnames: "{{ osp_controller_internal_api_hostnames|default([]) }} + [ '{{ item.value.internal_api_hostname }}' ]"
-    loop: "{{ osp_inventory.Controller.hosts|dict2items }}"
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
 
   - name: create service secret
     block:
+    - set_fact:
+        osp_worker_yaml_dir: "{{ working_yamls_dir }}/osp-worker"
+
+    - debug:
+        msg: "yamls will be written to {{ osp_worker_yaml_dir }} locally"
+
+    - name: Create yaml dir
+      file:
+        path: "{{ osp_worker_yaml_dir }}"
+        state: directory
+
     - name: delete osp-secrets secret (reinstall/rerun)
       command: oc delete secret osp-secrets -n openstack
-      args:
-        chdir: "{{ base_path }}"
       environment:
-        PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-        KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
       ignore_errors: true
 
-    - name: create rabbit_transport_url secret
-      block:
-      - set_fact:
-          rabbit_transport_url: "{{ rabbit_transport_url }}{{ (rabbit_transport_url|length > 0) | ternary(',', '', omit) }}guest:{{ osp_global_config_settings.oslo_messaging_rpc_password }}@{{ item }}:5672"
-        with_items:
-        - "{{ osp_controller_internal_api_hostnames }}"
-      - set_fact:
-          rabbit_transport_url: "rabbit://{{ rabbit_transport_url }}/?ssl=0"
-
     - set_fact:
-        rabbit_transport_url: "{{ rabbit_transport_url | b64encode }}"
-        cinder_password: "{{ osp_controller.service_configs['cinder::keystone::auth::password'] | b64encode }}"
-        nova_password: "{{ osp_controller.service_configs['nova::keystone::auth::password'] | b64encode }}"
-        neutron_password: "{{ osp_controller.service_configs['neutron::keystone::auth::password'] | b64encode }}"
-        placement_password: "{{ osp_controller.service_configs['placement::keystone::auth::password'] | b64encode }}"
+        rabbit_transport_url: "{{ 'rabbit://cell1:passw0rd@rabbitmq.openstack.svc:5672/cell1?ssl=0' | b64encode }}"
+        cinder_password: "{{ 'foobar123' | b64encode }}"
+        nova_password: "{{ 'foobar123' | b64encode }}"
+        neutron_password: "{{ 'foobar123' | b64encode }}"
+        placement_password: "{{ 'foobar123' | b64encode }}"
 
     - name: create osp-secret.yaml secret from template
       template:
         src:  osp-secrets.yaml.j2
-        dest: "{{ base_path }}/osp-secrets.yaml"
-        mode: 0644
+        dest: "{{ osp_worker_yaml_dir }}/osp-secrets.yaml"
 
-    - name: create osp-service-secret secret
-      shell: >
-        oc apply -f {{ base_path }}/osp-secrets.yaml
-      args:
-        chdir: "{{ base_path }}"
+  - name: create service secret
+    block:
+    - name: copy openstackclient-cm.yaml to {{ osp_worker_yaml_dir }}
+      copy:
+        src: files/ocp/openstackclient-cm.yaml
+        dest: "{{ osp_worker_yaml_dir }}/openstackclient-cm.yaml"
+
+    - name: create openstackclient configMap
+      shell: |
+        set -e
+        oc apply -f {{ osp_worker_yaml_dir }}/openstackclient-cm.yaml
       environment:
-        PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-        KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: copy openstackclient-admin-secret.yaml to {{ osp_worker_yaml_dir }}
+      copy:
+        src: files/ocp/openstackclient-admin-secret.yaml
+        dest: "{{ osp_worker_yaml_dir }}/openstackclient-admin-secret.yaml"
+
+    - name: create openstackclient admin user secret
+      shell: |
+        set -e
+        oc apply -f {{ osp_worker_yaml_dir }}/openstackclient-admin-secret.yaml
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+  - name: apply yamls from {{ osp_worker_yaml_dir }}
+    shell: |
+      set -e
+      oc apply -f {{ osp_worker_yaml_dir }}/
+    environment:
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -40,6 +40,7 @@ osp_operators_install: compute_node
 compute_node: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-i hosts -e @local-defaults.yaml \
+        09_create_common-config.yaml \
 	12_setup_worker_osp_machineset.yaml \
 
 osp_tests_run: hosts local-defaults.yaml

--- a/ansible/files/ocp/nova-api/2/configmap.yaml
+++ b/ansible/files/ocp/nova-api/2/configmap.yaml
@@ -134,3 +134,13 @@ data:
     [scheduler]
     # run periodic task to discover hosts automatically
     discover_hosts_in_cells_interval = 60
+
+    [neutron]
+    region_name = regionOne
+    project_domain_name = Default
+    project_name = service
+    auth_type = password
+    user_domain_name = Default
+    auth_url = http://keystone.openstack.svc:5000/
+    username = neutron
+    password = foobar123

--- a/ansible/files/ocp/openstackclient-cm.yaml
+++ b/ansible/files/ocp/openstackclient-cm.yaml
@@ -12,7 +12,7 @@ data:
   OS_CLOUDNAME: "overcloud"
   PYTHONWARNINGS: "ignore:Certificate has no, ignore:A true SSLContext object is not available"
   OS_AUTH_TYPE: "password"
-  OS_AUTH_URL: "http://192.168.25.100:5000"
+  OS_AUTH_URL: "http://keystone.openstack.svc:5000"
   OS_IDENTITY_API_VERSION: "3"
   OS_COMPUTE_API_VERSION: "2.latest"
   OS_IMAGE_API_VERSION: "2"

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -53,7 +53,7 @@ opm_version: v1.12.5
 #openstack_k8s_operators_heat_branch: defaults to "HEAD"
 
 # operator images and tag to use
-nova_operator_image: quay.io/openstack-k8s-operators/nova-operator:v0.0.3
+nova_operator_image: quay.io/openstack-k8s-operators/nova-operator:v0.0.4
 neutron_operator_image: quay.io/openstack-k8s-operators/neutron-operator:v0.0.4
 compute_node_operator_image: quay.io/openstack-k8s-operators/compute-node-operator:v0.0.4
 cluster_operator_image: quay.io/openstack-k8s-operators/openstack-cluster-operator:v0.0.1


### PR DESCRIPTION
To now have massive changes right now we create the required
input resources for the nova-operator and clean it up afterwards.

Also adds the required [neutron] section to the nova-api cm.