### PR TITLE
nova: Make compute service names prettier

### DIFF
--- a/ansible/files/ocp/nova-api/4/sts-scheduler.yaml
+++ b/ansible/files/ocp/nova-api/4/sts-scheduler.yaml
@@ -1,10 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: &name nova-api-super-conductor
+  name: &name nova-api-scheduler
   namespace: &namespace openstack
 spec:
   replicas: 1
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       app: *name
@@ -16,7 +17,7 @@ spec:
         app: *name
     spec:
       containers:
-      - image: tripleotrain/rhel-binary-nova-conductor:current-tripleo
+      - image: tripleotrain/rhel-binary-nova-scheduler:current-tripleo
         name: nova-api-kolla
         env:
         - name: KOLLA_CONFIG_STRATEGY
@@ -37,7 +38,7 @@ spec:
           name: nova-api
           defaultMode: 0444
           items:
-          - key: kolla-config-super-conductor.json
+          - key: kolla-config-scheduler.json
             path: config.json
       - name: config-data
         configMap:

--- a/ansible/files/ocp/nova-api/4/sts-super-conductor.yaml
+++ b/ansible/files/ocp/nova-api/4/sts-super-conductor.yaml
@@ -1,10 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: &name nova-api-scheduler
+  name: &name nova-api-super-conductor
   namespace: &namespace openstack
 spec:
   replicas: 1
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       app: *name
@@ -16,7 +17,7 @@ spec:
         app: *name
     spec:
       containers:
-      - image: tripleotrain/rhel-binary-nova-scheduler:current-tripleo
+      - image: tripleotrain/rhel-binary-nova-conductor:current-tripleo
         name: nova-api-kolla
         env:
         - name: KOLLA_CONFIG_STRATEGY
@@ -37,7 +38,7 @@ spec:
           name: nova-api
           defaultMode: 0444
           items:
-          - key: kolla-config-scheduler.json
+          - key: kolla-config-super-conductor.json
             path: config.json
       - name: config-data
         configMap:

--- a/ansible/files/ocp/nova-cell/3/sts-conductor.yaml
+++ b/ansible/files/ocp/nova-cell/3/sts-conductor.yaml
@@ -1,10 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: &name nova-cell1-conductor
   namespace: &namespace openstack
 spec:
   replicas: 1
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       app: *name


### PR DESCRIPTION
Pods created by a Deployment have a hash in their name. Pods created
by a StatefulSet have a consistent name with sequential numbering.
This change switches to consistent naming for pods whose hostname is
presented via the openstack api. As well as looking nicer, it also
means we don't need to cleanup resources every time a pod restarts,
only if we scale the service down.