### PR TITLE
Specify $NAMESPACE as openstack

### DIFF
--- a/ansible/olm.yaml
+++ b/ansible/olm.yaml
@@ -59,6 +59,7 @@
       KEYSTONE_IMAGE: "{{keystone_operator_image}}"
       MARIADB_IMAGE: "{{mariadb_operator_image}}"
       GLANCE_IMAGE: "{{glance_operator_image}}"
+      NAMESPACE: openstack
 
   - name: switch to openstack project/namespace
     shell: >


### PR DESCRIPTION
Override the default namespace used by openstack-cluster-operator and
use the openstack namespace that we are using in the ansible automation
instead.