### PR TITLE
Use pip3 instead of pip

### DIFF
--- a/ansible/04_local_oc_client.yaml
+++ b/ansible/04_local_oc_client.yaml
@@ -14,7 +14,7 @@
 
   - name: Install openstack client
     shell: |
-      pip install --user python-openstackclient osc-placement
+      pip3 install --user python-openstackclient osc-placement
 
   - name: Create environment file
     template:


### PR DESCRIPTION
Needed `pip3` instead of `pip` to install openstack client, otherwise `make post_install` was failing