### PR TITLE
Refactor ctlplane automation for operator changes

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -53,21 +53,28 @@ osp_tests_run: hosts local-defaults.yaml
 	-i hosts -e @local-defaults.yaml \
   20_tempest_ocp.yaml \
 
-podified-ctlplane: hosts ctlplane
-ctlplane: local-defaults.yaml
+ctlplane-operator: local-defaults.yaml
 	# NOTE: requires 'make olm'
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-i hosts -e @local-defaults.yaml \
 	install_namespace.yaml \
-	install_mariadb.yaml \
+	install_ctlplane.yaml \
+
+ctlplane-yamls: local-defaults.yaml
+	# NOTE: requires 'make olm'
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-i hosts -e @local-defaults.yaml \
 	install_rabbitmq.yaml \
-	install_keystone.yaml \
-	install_glance.yaml \
+	install_osconfig.yaml \
+	install_glance_service_init.yaml \
 	install_placement.yaml \
 	install_ovn.yaml \
 	install_neutron-api.yaml \
 	install_nova-api.yaml \
 	install_nova-cell.yaml
+
+podified-ctlplane: hosts ctlplane
+ctlplane: local-defaults.yaml ctlplane-operator ctlplane-yamls
 
 olm: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \

--- a/ansible/files/ocp/ctlplane/ctlplane.yaml
+++ b/ansible/files/ocp/ctlplane/ctlplane.yaml
@@ -1,0 +1,11 @@
+apiVersion: controlplane.openstack.org/v1beta1
+kind: ControlPlane
+metadata:
+  name: openstack-ctlplane
+  namespace: openstack
+spec:
+  glance:
+    replicas: 1
+  keystone:
+    replicas: 1
+  storage_class: host-nfs-storageclass

--- a/ansible/install_ctlplane.yaml
+++ b/ansible/install_ctlplane.yaml
@@ -1,0 +1,78 @@
+---
+- hosts: localhost
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
+  tasks:
+  - set_fact:
+      ctlplane_yaml_dir: "{{ working_yamls_dir }}/ctlplane"
+
+  - debug:
+      msg: "yamls will be written to {{ ctlplane_yaml_dir }} locally"
+
+  - name: Create yaml dir
+    file:
+      path: "{{ ctlplane_yaml_dir }}"
+      state: directory
+
+  - name: Copy files to yaml dir
+    copy:
+      src: "{{ item }}"
+      dest: "{{ ctlplane_yaml_dir }}/"
+    with_fileglob:
+    - "ocp/ctlplane/*"
+
+  - name: Start ctlplane
+    shell: |
+      set -e
+      oc apply -n openstack -f "{{ ctlplane_yaml_dir }}"
+    environment: &oc_env
+      <<: *oc_env
+
+  - name: Wait for mariadb pod creation
+    shell: |
+      oc get -n openstack pod/mariadb
+    environment:
+      <<: *oc_env
+    register: mariadb_pod_creation
+    until: mariadb_pod_creation is not failed
+    retries: "{{ (default_timeout / 5)|int }}"
+    delay: 5
+
+  - name: Wait for mariadb deployment
+    shell: |
+      oc wait -n openstack pod/mariadb --for condition=ready --timeout={{ default_timeout }}s
+    environment:
+      <<: *oc_env
+
+  - name: Wait for keystone deployment to be created
+    shell: |
+      oc get -n openstack deployment/keystone
+    environment:
+      <<: *oc_env
+    register: keystone_deployment_creation
+    until: keystone_deployment_creation is not failed
+    retries: "{{ (default_timeout / 5)|int }}"
+    delay: 5
+
+  - name: Wait for keystone deployment
+    shell: |
+      oc wait -n openstack deployment/keystone --for condition=Available \
+          --timeout={{ default_timeout }}s
+    environment:
+      <<: *oc_env
+
+  # This workaround can be removed when
+  # https://issues.redhat.com/browse/OSPK8-248 is resolved.
+  - name: Wait for keystone bootstrap
+    shell: |
+      set -e -o pipefail
+
+      oc get -n openstack keystoneapi/keystone -o json | jq -re '.status.bootstrapHash'
+    environment:
+      <<: *oc_env
+    register: keystone_bootstrap
+    until: keystone_bootstrap is not failed and keystone_bootstrap.stdout != ""
+    retries: "{{ (default_timeout / 5)|int }}"
+    delay: 5

--- a/ansible/install_glance_service_init.yaml
+++ b/ansible/install_glance_service_init.yaml
@@ -1,0 +1,36 @@
+---
+- hosts: localhost
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
+  tasks:
+  - set_fact:
+      glance_yaml_dir: "{{ working_yamls_dir }}/glance"
+
+  - debug:
+      msg: "yamls will be written to {{ glance_yaml_dir }} locally"
+
+  - name: Create yaml dir
+    file:
+      path: "{{ glance_yaml_dir }}"
+      state: directory
+
+  - name: Copy files to yaml dir
+    copy:
+      src: "{{ item }}"
+      dest: "{{ glance_yaml_dir }}/"
+    with_items:
+    - "ocp/glance/service-init-cmds.yaml"
+    - "ocp/glance/service-init-job.yaml"
+
+  - name: Start glance
+    shell: |
+      set -e
+      oc apply -n openstack -f "{{ glance_yaml_dir ~ '/' ~ item }}"
+    environment:
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+    with_items:
+    - "service-init-cmds.yaml"
+    - "service-init-job.yaml"

--- a/ansible/install_osconfig.yaml
+++ b/ansible/install_osconfig.yaml
@@ -1,0 +1,30 @@
+---
+- hosts: localhost
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
+  tasks:
+  - name: Create yaml dir
+    import_role: name=working_yaml_dir
+    vars:
+      name: keystone
+
+  - name: Copy files to yaml dir
+    copy:
+      src: "{{ item }}"
+      dest: "{{ keystone_yaml_dir }}/"
+    with_fileglob:
+    - "ocp/keystone/osconfig.yaml"
+
+  - name: create keystone osconfig
+    shell: |
+      oc apply -n openstack -f "{{ keystone_yaml_dir }}"/osconfig.yaml
+    environment: &oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
+
+  - name: copy stackrc to working dir
+    copy:
+      src: stackrc
+      dest: "{{ working_dir }}/stackrc"


### PR DESCRIPTION
- Break out osconfig and glance service init into separate playbooks
- Add playbook for deploying ctlplane CR
- Break out ctlplane Makefile target into ctlplane-operator and
  ctlplane-yamls

The ctlplane target still works as it did previously, and will deploy
both the operator and yaml pieces of the control plane.