### PR TITLE
prepare_host: Remove unnecessary host configuration

### DIFF
--- a/ansible/01_prepare_host.yaml
+++ b/ansible/01_prepare_host.yaml
@@ -23,12 +23,6 @@
 
   - name: Register host to subscription manager, metal3 dev scripts use subscription manager for RHEL
     block:
-    - name: Install and execute rhos-release.
-      import_role:
-        name: prepare-rhos-release
-      vars:
-        rhos_release_args: "-x"
-
     - name: use local rhel-subscription info
       when: secrets_repo is undefined
       block:
@@ -83,8 +77,8 @@
         org_id: "{{ rhel_subscription_org_id }}"
         pool: '^(Red Hat Enterprise Server for x86_64)$'
 
-    - name: enable rhel-8-for-x86_64-appstream-rpms and openstack-16-for-rhel-8-x86_64-rpms repos
-      command: subscription-manager repos --enable=openstack-16-for-rhel-8-x86_64-rpms --enable=rhel-8-for-x86_64-appstream-rpms --enable=advanced-virt-for-rhel-8-x86_64-rpms
+    - name: enable rhel-8-for-x86_64-appstream-rpms and advanced-virt-for-rhel-8-x86_64-rpms
+      command: subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms --enable=advanced-virt-for-rhel-8-x86_64-rpms
 
   - name: install packages and enable services
     block:
@@ -92,39 +86,21 @@
       package:
         state: installed
         name:
+          # Directly configured/used in this playbook
           - chrony
-          - vim-enhanced
-          - tmux
-          - mlocate
           - sysstat
           - cronie
-          - libvirt-daemon-kvm
-          - libvirt-client
-          - libguestfs-tools
-          - libvirt
-          - libvirt-devel
-          - libguestfs-tools
-          - telnet
-          - bind-utils
-          - virt-manager
-          - wget
-          - git
-          - xorg-x11-xauth
-          - xorg-x11-fonts-Type1
-          - qemu-kvm
-          - qemu-img
           - tuned
           - firewalld
-          - python3-openstackclient
-          - python3-ironicclient
-          - python3-osc-placement
+
+          # Required for dev-scripts
+          - libvirt-daemon-kvm
+          - libvirt-client
+          - libvirt
           - podman
           - buildah
-          - podman-docker
-          - golang
           - git
           - make
-          - golang-docs
 
     - name: Enable helpful services
       service: name={{ item }} enabled=yes state=started
@@ -134,9 +110,6 @@
         - chronyd
         - tuned
         - firewalld
-
-    - name: Update mlocate
-      shell: updatedb
 
   - name: configure time on host
     block:
@@ -192,25 +165,6 @@
         name: kvm_intel
         state: present
 
-  - name: create eth1 dummy interface
-    block:
-    - name: check if eth1 dummy interface already exist
-      stat:
-        path: /sys/class/net/eth1
-      register: dummy_if_exists
-    - name: create eth1 dummy interface
-      command: ip link add dev eth1 type dummy
-      when: dummy_if_exists.stat.exists == False
-    - name: make dummy interface persistent for reboot, for now use rc.local. correct  i
-      lineinfile:
-        path: /etc/rc.d/rc.local
-        regexp: '^ip link add dev eth1 type dummy'
-        line: ip link add dev eth1 type dummy
-    - name: make rc.local exec
-      file:
-        path: /etc/rc.d/rc.local
-        mode: '0775'
-
   - name: Remove home mount point
     mount:
       path: /home
@@ -242,23 +196,6 @@
         /usr/sbin/xfs_growfs /
       when: lv_resized is changed
 
-  - name: Enable RH CSB repository for CA cert
-    copy:
-      dest: /etc/yum.repos.d/rhel8-csb.repo
-      content: |
-        [rhel8-csb]
-        name=RHEL8 CSB packages
-        baseurl=http://hdn.corp.redhat.com/rhel8-csb
-        enabled=1
-        gpgcheck=0
-        priority=2
-        includepkgs=redhat-internal-cert-install
-
-  - name: Install helpful packages
-    package: name={{ item }} state=installed
-    with_items:
-      - redhat-internal-cert-install
-
   - name: Allow 'wheel' group to have passwordless sudo
     lineinfile:
       dest: /etc/sudoers
@@ -270,25 +207,6 @@
   - name: make sure /home is there as the mount plugin with absent removed it earlier
     file:
       path: /home
-      state: directory
-      mode: '0755'
-
-  - name: create ocp group
-    group:
-      name: ocp
-      state: present
-
-  - name: Create user to run metal3 installer dev scripts
-    user:
-      name: ocp
-      comment: ocp user
-      shell: /bin/bash
-      group: ocp
-      groups: wheel
-
-  - name: make sure /home/ocp is world readable
-    file:
-      path: /home/ocp
       state: directory
       mode: '0755'
 

--- a/ansible/03_ocp_dev_scripts_prep.yaml
+++ b/ansible/03_ocp_dev_scripts_prep.yaml
@@ -1,5 +1,30 @@
 ---
 - hosts: convergence_base
+  gather_facts: false
+  become: true
+
+  tasks:
+  - name: create ocp group
+    group:
+      name: ocp
+      state: present
+
+  - name: Create user to run metal3 installer dev scripts
+    user:
+      name: ocp
+      comment: ocp user
+      shell: /bin/bash
+      group: ocp
+      groups: wheel
+
+  - name: make sure /home/ocp is world readable
+    file:
+      path: /home/ocp
+      state: directory
+      mode: '0755'
+
+- hosts: convergence_base
+  gather_facts: false
   become: true
   become_user: ocp
 


### PR DESCRIPTION
This is a cleanup of openstack and workstation configuration on the
OCP host which are no longer required. This may not quite be a minimal
set, as I believe dev-scripts will install podman and buildah.
However, this is the set I tested.

This also removes some workstation tools we were installing on the OCP
host under the assumption that it is also used as a workstation. Any
required tools should be added back to 04_local_oc_client.yaml,
although I don't believe there are any. Personal preference tools can
be installed manually on individual workstations.