### PR TITLE
Kni-ipi-virt + OCS support

### DIFF
--- a/ansible/01_prepare_host.yaml
+++ b/ansible/01_prepare_host.yaml
@@ -21,7 +21,8 @@
         state: absent
       with_items: "{{ beaker_files_to_delete.files }}"
 
-  - name: Register host to subscription manager, metal3 dev scripts use subscription manager for RHEL
+  - name: Register host to subscription manager, {{ (use_kni_ipi_virt) | ternary('kni-ipi-virt uses','metal3 dev scripts use') }} subscription manager for RHEL
+    when: not skip_subscription
     block:
     - name: Install and execute rhos-release.
       import_role:
@@ -96,6 +97,7 @@
           - vim-enhanced
           - tmux
           - mlocate
+          - net-tools
           - sysstat
           - cronie
           - libvirt-daemon-kvm
@@ -278,13 +280,14 @@
       name: ocp
       state: present
 
-  - name: Create user to run metal3 installer dev scripts
+  - name: create ocp user to run {{ (use_kni_ipi_virt) | ternary('kni-ipi-virt','metal3 installer dev-scripts') }} 
     user:
       name: ocp
       comment: ocp user
       shell: /bin/bash
       group: ocp
       groups: wheel
+      generate_ssh_key: yes
 
   - name: make sure /home/ocp is world readable
     file:

--- a/ansible/01_prepare_host.yaml
+++ b/ansible/01_prepare_host.yaml
@@ -22,7 +22,7 @@
       with_items: "{{ beaker_files_to_delete.files }}"
 
   - name: Register host to subscription manager, {{ (use_kni_ipi_virt) | ternary('kni-ipi-virt uses','metal3 dev scripts use') }} subscription manager for RHEL
-    when: not skip_subscription
+    when: not (skip_subscription | default(false))
     block:
     - name: Install and execute rhos-release.
       import_role:

--- a/ansible/03_ocp_dev_scripts.yaml
+++ b/ansible/03_ocp_dev_scripts.yaml
@@ -7,7 +7,7 @@
   - name: Include variables
     include_vars: vars/default.yaml
 
-  - name: cleanup previous dev-script deployment
+  - name: cleanup previous {{ (use_kni_ipi_virt) | ternary('kni-ipi-virt','dev-scripts') }} deployment
     shell: |
       export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
       make clean
@@ -16,14 +16,14 @@
 
   - debug:
       msg: |
-        Executing dev-script. You can tail the logs at ~ocp/dev-script.log on
+        Executing {{ (use_kni_ipi_virt) | ternary('kni-ipi-virt','dev-scripts') }}. You can tail the logs at /home/ocp/{{ (use_kni_ipi_virt) | ternary('kni-ipi-virt','dev-script') }}.log on
         the host for progress.
 
-  - name: run dev-script
+  - name: run {{ (use_kni_ipi_virt) | ternary('kni-ipi-virt','dev-scripts') }}
     shell: |
       set -o pipefail
       export PS4='+(${BASH_SOURCE}:${LINENO}): ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-      make 2>&1 | tee ~/dev-script.log
+      make 2>&1 | tee ~/{{ (use_kni_ipi_virt) | ternary('kni-ipi-virt','dev-script') }}.log
     args:
       chdir: "{{ base_path }}/dev-scripts"
     environment:

--- a/ansible/03_ocp_dev_scripts_prep.yaml
+++ b/ansible/03_ocp_dev_scripts_prep.yaml
@@ -7,30 +7,11 @@
   - name: Include variables
     include_vars: vars/default.yaml
 
-  - name: Clone the dev-scripts repo
+  - name: Clone {{ (use_kni_ipi_virt) | ternary('kni-ipi-virt','dev-scripts') }} repo
     git:
       repo: "{{ dev_scripts_repo | default('https://github.com/openshift-metal3/dev-scripts.git', true) }}"
       dest: "{{ base_path }}/dev-scripts"
       version: "{{ dev_scripts_branch | default('HEAD', true) }}"
-
-  - name: Copy the config_example.sh to config_$USER.sh
-    copy:
-      src: "{{ base_path }}/dev-scripts/config_example.sh"
-      dest: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      mode: 0755
-      remote_src: yes
-
-  - name: set OCP release to use
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export OPENSHIFT_RELEASE_IMAGE=.*'
-      line: "export OPENSHIFT_RELEASE_IMAGE={{ ocp_release_image }}"
-
-  - name: set WORKING_DIR in {{ base_path }}/dev-scripts/config_$USER.sh
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export WORKING_DIR='
-      line: export WORKING_DIR='{{ base_path }}'
 
   - name: Copy pull-secret file 
     when: secrets_repo is undefined
@@ -64,74 +45,208 @@
         dest: "{{ secrets_repo_path }}"
         version: "{{ secrets_branch | default('HEAD', true) }}"
 
-  - name: set PULL_SECRET in {{ base_path }}/dev-scripts/config_$USER.sh
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export PULL_SECRET='
-      line: export PULL_SECRET=$(cat "{{ secrets_repo_path }}/pull-secret")
+  - name: Prepare dev-scripts configuration
+    when: not use_kni_ipi_virt
+    block:
+    - name: Copy the config_example.sh to config_$USER.sh
+      copy:
+        src: "{{ base_path }}/dev-scripts/config_example.sh"
+        dest: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        mode: 0755
+        remote_src: yes
 
-  - name: set IP_STACK in {{ base_path }}/dev-scripts/config_$USER.sh
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export IP_STACK='
-      line: export IP_STACK='{{ ocp_ip_stack }}'
+    - name: set OCP release to use
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export OPENSHIFT_RELEASE_IMAGE=.*'
+        line: "export OPENSHIFT_RELEASE_IMAGE={{ ocp_release_image }}"
 
-  - name: set CLUSTER_NAME in {{ base_path }}/dev-scripts/config_$USER.sh
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export CLUSTER_NAME='
-      line: export CLUSTER_NAME='{{ ocp_cluster_name }}'
+    - name: set WORKING_DIR in {{ base_path }}/dev-scripts/config_$USER.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export WORKING_DIR='
+        line: export WORKING_DIR='{{ base_path }}'
 
-  - name: set OCP number of workers
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export NUM_WORKERS=.*'
-      line: "export NUM_WORKERS={{ ocp_num_workers }}"
+    - name: set PULL_SECRET in {{ base_path }}/dev-scripts/config_$USER.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export PULL_SECRET='
+        line: export PULL_SECRET=$(cat "{{ secrets_repo_path }}/pull-secret")
 
-  - name: set OCP number of masters
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export NUM_MASTERS=.*'
-      line: "export NUM_MASTERS={{ ocp_num_masters | default('3', true)}}"
+    - name: set IP_STACK in {{ base_path }}/dev-scripts/config_$USER.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export IP_STACK='
+        line: export IP_STACK='{{ ocp_ip_stack }}'
 
-  - name: set OCP master memory
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export MASTER_MEMORY=.*'
-      line: "export MASTER_MEMORY={{ ocp_master_memory }}"
+    - name: set CLUSTER_NAME in {{ base_path }}/dev-scripts/config_$USER.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export CLUSTER_NAME='
+        line: export CLUSTER_NAME='{{ ocp_cluster_name }}'
 
-  - name: set OCP network type
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export NETWORK_TYPE=.*'
-      line: "export NETWORK_TYPE={{ ocp_network_type }}"
+    - name: set OCP number of workers
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export NUM_WORKERS=.*'
+        line: "export NUM_WORKERS={{ ocp_num_workers }}"
 
-  - name: set OCP master disk
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export MASTER_DISK=.*'
-      line: "export MASTER_DISK={{ ocp_master_disk }}"
+    - name: set OCP number of masters
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export NUM_MASTERS=.*'
+        line: "export NUM_MASTERS={{ ocp_num_masters | default('3', true)}}"
 
-  - name: set OCP master vcpus
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export MASTER_VCPU=.*'
-      line: "export MASTER_VCPU={{ ocp_master_vcpu }}"
+    - name: set OCP master memory
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export MASTER_MEMORY=.*'
+        line: "export MASTER_MEMORY={{ ocp_master_memory }}"
 
-  - name: set OCP worker memory
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export WORKER_MEMORY=.*'
-      line: "export WORKER_MEMORY={{ ocp_worker_memory }}"
+    - name: set OCP network type
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export NETWORK_TYPE=.*'
+        line: "export NETWORK_TYPE={{ ocp_network_type }}"
 
-  - name: set OCP worker disk
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export WORKER_DISK=.*'
-      line: "export WORKER_DISK={{ ocp_worker_disk }}"
+    - name: set OCP master disk
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export MASTER_DISK=.*'
+        line: "export MASTER_DISK={{ ocp_master_disk }}"
 
-  - name: set OCP worker vcpus
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export WORKER_VCPU=.*'
-      line: "export WORKER_VCPU={{ ocp_worker_vcpu }}"
+    - name: set OCP master vcpus
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export MASTER_VCPU=.*'
+        line: "export MASTER_VCPU={{ ocp_master_vcpu }}"
+
+    - name: set OCP worker memory
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export WORKER_MEMORY=.*'
+        line: "export WORKER_MEMORY={{ ocp_worker_memory }}"
+
+    - name: set OCP worker disk
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export WORKER_DISK=.*'
+        line: "export WORKER_DISK={{ ocp_worker_disk }}"
+
+    - name: set OCP worker vcpus
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+        regexp: '^export WORKER_VCPU=.*'
+        line: "export WORKER_VCPU={{ ocp_worker_vcpu }}"
+
+
+  - name: Prepare kni-ipi-virt configuration
+    when: use_kni_ipi_virt
+    block:
+    - name: set OCP release to use
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export OCP_VERSION=.*'
+        line: 'export OCP_VERSION={{ ocp_release_image.split(":")[1].split("-")[0] }}'
+
+    - name: set CLUSTER_CONFIGS_DIR in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export CLUSTER_CONFIGS_DIR='
+        line: 'export CLUSTER_CONFIGS_DIR="{{ base_path }}/dev-scripts/ocp/{{ ocp_cluster_name }}"'
+
+    - name: set PROJECT_DIR in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export PROJECT_DIR='
+        line: export PROJECT_DIR="{{ base_path }}/dev-scripts"
+
+    - name: set PULL_SECRET in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export PULL_SECRET_PATH='
+        line: export PULL_SECRET_PATH="{{ secrets_repo_path }}/pull-secret"
+
+    - name: set CLUSTER_DOMAIN in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export CLUSTER_DOMAIN='
+        line: export CLUSTER_DOMAIN=test.metalkube.org
+
+    - name: set CLUSTER_NAME in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export CLUSTER_NAME='
+        line: export CLUSTER_NAME='{{ ocp_cluster_name }}'
+
+    - name: set BM_CIDR in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export BM_CIDR='
+        line: export BM_CIDR='192.168.111.0/24'
+
+    - name: set BM_GW_IP in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export BM_GW_IP='
+        line: export BM_GW_IP='192.168.111.1'
+
+    - name: set DNS_VIP in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export DNS_VIP='
+        line: export DNS_VIP='192.168.111.3'
+
+    - name: set INGRESS_VIP in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export INGRESS_VIP='
+        line: export INGRESS_VIP='192.168.111.4'
+
+    - name: set API_VIP in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export API_VIP='
+        line: export API_VIP='192.168.111.5'
+
+    - name: set OCP number of workers
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export NUM_WORKERS=.*'
+        line: "export NUM_WORKERS={{ ocp_num_workers }}"
+
+    - name: set OCP number of masters
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export NUM_MASTERS=.*'
+        line: "export NUM_MASTERS={{ ocp_num_masters | default('3', true)}}"
+
+    - name: set OCP master memory
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export MASTER_MEM=.*'
+        line: "export MASTER_MEM={{ ocp_master_memory }}"
+
+    - name: set OCP master vcpus
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export MASTER_CPUS=.*'
+        line: "export MASTER_CPUS={{ ocp_master_vcpu }}"
+
+    - name: set OCP worker memory
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export WORKER_MEM=.*'
+        line: "export WORKER_MEM={{ ocp_worker_memory }}"
+
+    - name: set OCP worker vcpus
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export WORKER_CPUS=.*'
+        line: "export WORKER_CPUS={{ ocp_worker_vcpu }}"
+
+    - name: use remote registry for OCP images
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export CREATE_LOCAL_REG=.*'
+        line: "export CREATE_LOCAL_REG=false"

--- a/ansible/03_ocp_dev_scripts_prep.yaml
+++ b/ansible/03_ocp_dev_scripts_prep.yaml
@@ -209,6 +209,18 @@
         regexp: '^export API_VIP='
         line: export API_VIP='192.168.111.5'
 
+    - name: set PROV_BRIDGE in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export PROV_BRIDGE='
+        line: "export PROV_BRIDGE='{{ ocp_cluster_name }}pr'"
+
+    - name: set BM_BRIDGE in {{ base_path }}/dev-scripts/common.sh
+      lineinfile:
+        path: "{{ base_path }}/dev-scripts/common.sh"
+        regexp: '^export BM_BRIDGE='
+        line: "export BM_BRIDGE='{{ ocp_cluster_name }}bm'"
+
     - name: set OCP number of workers
       lineinfile:
         path: "{{ base_path }}/dev-scripts/common.sh"

--- a/ansible/04_local_oc_client.yaml
+++ b/ansible/04_local_oc_client.yaml
@@ -36,7 +36,7 @@
   - name: Copy kubeconfig
     fetch:
       dest: "{{ hostvars['localhost']['kubeconfig'] }}"
-      src: "{{ base_path }}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
+      src: "{{ kubeconfig_path }}"
       flat: true
 
   - name: Copy oc binary

--- a/ansible/06_osp_storage.yaml
+++ b/ansible/06_osp_storage.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  gather_facts: false
+  vars_files: vars/default.yaml
+  tasks:
+    - block:
+        - name: Provision and install OCS storage
+          include: ocs.yaml
+      when: ocs_enabled == true and use_kni_ipi_virt == true

--- a/ansible/12_setup_worker_osp_machineset.yaml
+++ b/ansible/12_setup_worker_osp_machineset.yaml
@@ -38,7 +38,7 @@
       set -e -o pipefail
 
       oc get -n openshift-machine-api bmh --no-headers -o custom-columns=name:.metadata.name | \
-          grep "^{{ ocp_cluster_name }}-worker-"
+          grep "worker-"
     environment:
       <<: *oc_env
     register: baremetalhosts_out

--- a/ansible/20_tempest_ocp.yaml
+++ b/ansible/20_tempest_ocp.yaml
@@ -55,7 +55,7 @@
         oc create configmap tempest-config --from-file {{ base_path }}/container_tempest_cfg
       environment:
         PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-        KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
+        KUBECONFIG: "{{ kubeconfig_path }}"
 
     - name: create tempest-bin ConfigMap
       become_user: ocp
@@ -66,7 +66,7 @@
         oc create configmap tempest-bin --from-file {{ base_path }}/container_tempest_bin
       environment:
         PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-        KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
+        KUBECONFIG: "{{ kubeconfig_path }}"
 
     - name: create tempest pod
       become_user: ocp
@@ -77,7 +77,7 @@
         oc apply -f {{ base_path }}/tempest-pod.yaml
       environment:
         PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-        KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
+        KUBECONFIG: "{{ kubeconfig_path }}"
 
     - name: wait for tempest pod in ready state
       become_user: ocp
@@ -85,7 +85,7 @@
         oc wait pod tempest --for condition=Ready --timeout="{{ tempest_timeout }}s"
       environment:
         PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-        KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
+        KUBECONFIG: "{{ kubeconfig_path }}"
       register: tempest_run
       ignore_errors: true
 
@@ -95,7 +95,7 @@
         oc logs tempest -c tempest-run
       environment:
         PATH: "/usr/local/bin:{{ ansible_env.PATH }}"
-        KUBECONFIG: "{{base_path}}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
+        KUBECONFIG: "{{ kubeconfig_path }}"
       register: tempest_result
 
     - name:

--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -87,6 +87,11 @@ olm: hosts local-defaults.yaml
 	install_namespace.yaml \
 	olm.yaml
 
+ocs: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-v -i hosts -e @local-defaults.yaml \
+	ocs.yaml
+
 openstackclient: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-v -i hosts -e @local-defaults.yaml \
@@ -114,7 +119,7 @@ ocp_cleanup: hosts
 	ANSIBLE_FORCE_COLOR=true ansible -i hosts convergence_base \
 	--become --become-user ocp \
 	-m shell -a "cd /home/ocp/dev-scripts && make clean"
-	$(MAKE) nfs_cleanup
+	$(MAKE) nfs_cleanup 
 
 demo: hosts
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
@@ -125,3 +130,8 @@ osp_cleanup: hosts local-defaults.yaml
 	ANSIBLE_FORCE_COLOR=true ansible-playbook \
 	-v -i hosts -e @local-defaults.yaml \
 	osp_cleanup.yaml
+
+ocs_cleanup: hosts local-defaults.yaml
+	ANSIBLE_FORCE_COLOR=true ansible-playbook \
+	-v -i hosts -e @local-defaults.yaml \
+	ocs_cleanup.yaml

--- a/ansible/ocs.yaml
+++ b/ansible/ocs.yaml
@@ -1,0 +1,276 @@
+---
+- hosts: convergence_base
+  gather_facts: false
+  become: true
+  user: root
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
+  tasks:
+  - name: Provision storage nodes and install OCS
+    when: ocs_enabled == true and use_kni_ipi_virt == true
+    block:
+    - name: Install non-pip dependencies
+      package:
+        name: "{{ item }}"
+        state: latest
+      with_items:
+        - virt-install
+
+    - name: Install pip dependencies
+      command: "pip3 install {{ item }}"
+      with_items:
+        - virtualbmc
+
+    - name: Clear host VM memory cache
+      shell: echo 3 | tee /proc/sys/vm/drop_caches
+
+    - name: Create storage VMs
+      shell: |
+        virt-install --ram 32768 --vcpus 12 --os-variant rhel8.0 --cpu host-passthrough \
+        --disk size={{ ocp_worker_disk }},pool=default,device=disk,bus=virtio,format=qcow2 --import --noautoconsole \
+        --vnc --network=bridge:provisioning,mac="52:54:00:82:68:6{{ item }}" \
+        --network=bridge:baremetal,mac="52:54:00:82:69:6{{ item }}" --name "{{ ocp_cluster_name}}-storage-{{ item }}" \
+        --os-type=linux --events on_reboot=restart --boot hd,network --noreboot
+      register: create_vms
+      failed_when: create_vms.stderr != "" and "is in use by another virtual machine" not in create_vms.stderr
+      with_items:
+        - 0
+        - 1
+        - 2
+
+    - name: Read host {{ ocs_device }} information
+      parted: device={{ ocs_device }} unit=MiB
+      register: device_info
+
+    - name: Create partitions on {{ ocs_device }}
+      shell: |
+        parted {{ ocs_device }} mkpart primary ext2 0% 10%;
+        parted {{ ocs_device }} mkpart primary ext2 10% 20%;
+        parted {{ ocs_device }} mkpart primary ext2 20% 30%;
+        parted {{ ocs_device }} mkpart extended 30% 100%;
+        parted {{ ocs_device }} mkpart logical ext2 40% 50%;
+        parted {{ ocs_device }} mkpart logical ext2 50% 60%;
+        parted {{ ocs_device }} mkpart logical ext2 60% 70%;
+        parted {{ ocs_device }} mkpart logical ext2 70% 80%;
+        parted {{ ocs_device }} mkpart logical ext2 80% 90%;
+        parted {{ ocs_device }} mkpart logical ext2 90% 100%
+      when: (device_info.partitions | length) == 0
+
+    - name: attach disks to storage VMs
+      command: "{{ item }}"
+      register: attach_disks
+      failed_when: attach_disks.stderr != "" and "already exists" not in attach_disks.stderr
+      with_items:
+        - "virsh attach-disk {{ ocp_cluster_name }}-storage-0 --source {{ ocs_device }}1 --target vdb --persistent"
+        - "virsh attach-disk {{ ocp_cluster_name }}-storage-0 --source {{ ocs_device }}2 --target vdc --persistent"
+        - "virsh attach-disk {{ ocp_cluster_name }}-storage-0 --source {{ ocs_device }}3 --target vdd --persistent"
+        - "virsh attach-disk {{ ocp_cluster_name }}-storage-1 --source {{ ocs_device }}5 --target vdb --persistent"
+        - "virsh attach-disk {{ ocp_cluster_name }}-storage-1 --source {{ ocs_device }}6 --target vdc --persistent"
+        - "virsh attach-disk {{ ocp_cluster_name }}-storage-1 --source {{ ocs_device }}7 --target vdd --persistent"
+        - "virsh attach-disk {{ ocp_cluster_name }}-storage-2 --source {{ ocs_device }}8 --target vdb --persistent"
+        - "virsh attach-disk {{ ocp_cluster_name }}-storage-2 --source {{ ocs_device }}9 --target vdc --persistent"
+        - "virsh attach-disk {{ ocp_cluster_name }}-storage-2 --source {{ ocs_device }}10 --target vdd --persistent"     
+
+    - name: Create and start storage VM vbmcs
+      shell: |
+        vbmc add "{{ ocp_cluster_name}}-storage-{{ item }}" --port "626{{ item }}" --username ADMIN --password ADMIN;
+        vbmc start "{{ ocp_cluster_name}}-storage-{{ item }}"
+      with_items:
+        - 0
+        - 1
+        - 2
+
+    - name: Open ports for storage VM vbmcs in firewalld
+      firewalld:
+        port: "626{{ item }}/udp"
+        permanent: yes
+        state: enabled
+        zone: "public"
+        immediate: yes
+      with_items:
+        - 0
+        - 1
+        - 2
+    
+    - name: Shutdown storage VMs using IPMI via vbmcs
+      shell: ipmitool -I lanplus -U ADMIN -P ADMIN -H 127.0.0.1 -p "626{{ item }}" power off
+      retries: 2
+      with_items:
+        - 0
+        - 1
+        - 2
+
+    - name: Add storage VM hostnames and IPs to DHCP server
+      blockinfile:
+        path: "{{ base_path }}/dev-scripts/dhcp/generated/bm/etc/dnsmasq.d/dnsmasq.hostsfile"
+        block: |
+          52:54:00:82:69:60,192.168.111.140,{{ ocp_cluster_name }}-storage-0.{{ ocp_cluster_name }}.test.metalkube.org
+          52:54:00:82:69:61,192.168.111.141,{{ ocp_cluster_name }}-storage-1.{{ ocp_cluster_name }}.test.metalkube.org
+          52:54:00:82:69:62,192.168.111.142,{{ ocp_cluster_name }}-storage-2.{{ ocp_cluster_name }}.test.metalkube.org
+    
+    - name: Restart DHCP server
+      shell: |
+        podman stop ipi-dnsmasq-bm;
+        podman start ipi-dnsmasq-bm
+
+    - name: Add storage VM hostnames and IP octet to DNS server
+      blockinfile:
+        path: "{{ base_path }}/dev-scripts/dns/generated/db.reverse"
+        block: |
+          140 IN  PTR {{ ocp_cluster_name }}-storage-0.{{ ocp_cluster_name }}.test.metalkube.org.
+          141 IN  PTR {{ ocp_cluster_name }}-storage-1.{{ ocp_cluster_name }}.test.metalkube.org.
+          142 IN  PTR {{ ocp_cluster_name }}-storage-2.{{ ocp_cluster_name }}.test.metalkube.org.
+
+    - name: Add storage VM hostnames and IPs DNS server
+      blockinfile:
+        path: "{{ base_path }}/dev-scripts/dns/generated/db.zone"
+        block: |
+          {{ ocp_cluster_name }}-storage-0                          A 192.168.111.140
+          {{ ocp_cluster_name }}-storage-1                          A 192.168.111.141
+          {{ ocp_cluster_name }}-storage-2                          A 192.168.111.142
+
+    - name: Restart DNS server
+      shell: |
+        podman stop ipi-coredns;
+        podman start ipi-coredns
+      become: yes
+      become_user: ocp
+
+    - name: Create OCS YAMLs working dir
+      file:
+        path: "{{ working_yamls_dir }}/ocs"
+        state: directory
+        mode: 0755
+
+    - name: Write OCS YAMLs to working dir
+      template:
+        src: ocs/{{ item }}.yaml.j2
+        dest: "{{ working_yamls_dir }}/ocs/{{ item }}.yaml"
+      with_items:
+        - bmhs
+        - local-storage-sub
+        - local-storage-volumes
+        - machineset
+        - ocs-storage-cluster
+        - ocs-sub
+
+    - name: Create storage machineset in OCP
+      shell: |
+        oc apply -f {{ working_yamls_dir }}/ocs/machineset.yaml -n openshift-machine-api
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Create storage baremetal hosts in OCP
+      shell: |
+        oc apply -f {{ working_yamls_dir }}/ocs/bmhs.yaml -n openshift-machine-api
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Wait for storage baremetal hosts to become ready
+      shell: oc get bmh -l test-storage=yes -n openshift-machine-api
+      retries: 100
+      delay: 30
+      register: storage_bmhs_ready
+      until: (storage_bmhs_ready.stdout | regex_findall('OK       ready') | length) == 3
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Scale storage machineset to 3
+      shell: oc scale machineset/{{ ocp_cluster_name }}-storage-0 --replicas=3 -n openshift-machine-api
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Wait for storage nodes to be provisioned
+      shell: oc get nodes -l node-role.kubernetes.io/storage
+      retries: 100
+      delay: 30
+      register: storage_nodes_ready
+      until: (storage_nodes_ready.stdout | regex_findall('Ready    storage') | length) == 3
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Label storage nodes as local-storage capable
+      shell: |
+        for i in $(oc get nodes --no-headers -l node-role.kubernetes.io/storage -o name); do
+          oc label $i cluster.ocs.openshift.io/openshift-storage=''
+        done
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+    
+    - name: Deploy local-storage subscription
+      shell: |
+        oc new-project local-storage
+        oc annotate project local-storage --overwrite openshift.io/node-selector=''
+        oc apply -f {{ working_yamls_dir }}/ocs/local-storage-sub.yaml
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Wait for local-storage operator to be ready
+      shell: oc get pods -n local-storage
+      retries: 100
+      delay: 20
+      register: local_storage_operator_ready
+      until: (local_storage_operator_ready.stdout | regex_findall('local-storage-operator-.+-.+Running') | length) == 1
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Create local-storage PVs
+      shell: |
+        oc apply -f {{ working_yamls_dir }}/ocs/local-storage-volumes.yaml
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Wait for local-storage PVs to be ready
+      shell: oc get pv -n local-storage
+      retries: 100
+      delay: 20
+      register: local_storage_volumes_ready
+      until: (local_storage_volumes_ready.stdout | regex_findall('local-pv-.+Available') | length) == (local_storage_volumes_ready.stdout | regex_findall('local-pv-.+') | length) and (local_storage_volumes_ready.stdout | regex_findall('local-pv-.+Available') | length) != 0
+
+    - name: Deploy OCS subscription
+      shell: oc apply -f {{ working_yamls_dir }}/ocs/ocs-sub.yaml
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Wait for OCS, rook-ceph and noobaa operators to be ready
+      shell: oc get pods -n openshift-storage
+      retries: 100
+      delay: 20
+      register: ocs_operators_ready
+      until: (ocs_operators_ready.stdout | regex_findall('ocs-operator-.+-.+Running') | length) == 1 and (ocs_operators_ready.stdout | regex_findall('rook-ceph-operator-.+-.+Running') | length) == 1 and (ocs_operators_ready.stdout | regex_findall('noobaa-operator-.+-.+Running') | length) == 1
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Deploy OCS cluster
+      shell: oc apply -f {{ working_yamls_dir }}/ocs/ocs-storage-cluster.yaml
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Wait for OCS pods to be ready
+      shell: oc get pods -n openshift-storage
+      retries: 100
+      delay: 30
+      register: ocs_pods_ready
+      until: ((ocs_pods_ready.stdout | regex_findall('csi-cephfsplugin-.+Running') | length) == (ocs_pods_ready.stdout | regex_findall('csi-cephfsplugin-.+') | length) and (ocs_pods_ready.stdout | regex_findall('csi-cephfsplugin-.+Running') | length) != 0)
+             and ((ocs_pods_ready.stdout | regex_findall('csi-rbdplugin-.+Running') | length) == (ocs_pods_ready.stdout | regex_findall('csi-rbdplugin-.+') | length) and (ocs_pods_ready.stdout | regex_findall('csi-rbdplugin-.+Running') | length) != 0)
+             and ((ocs_pods_ready.stdout | regex_findall('rook-ceph-mon-.+Running') | length) == (ocs_pods_ready.stdout | regex_findall('rook-ceph-mon-.+') | length) and (ocs_pods_ready.stdout | regex_findall('rook-ceph-mon-.+Running') | length) != 0)
+             and ((ocs_pods_ready.stdout | regex_findall('rook-ceph-osd-\d-.+Running') | length) == (ocs_pods_ready.stdout | regex_findall('rook-ceph-osd-\d-.+') | length) and (ocs_pods_ready.stdout | regex_findall('rook-ceph-osd-\d-.+Running') | length) != 0)
+             and ((ocs_pods_ready.stdout | regex_findall('noobaa-core-0.+Running') | length) == 1)
+             and ((ocs_pods_ready.stdout | regex_findall('noobaa-db-0.+Running') | length) == 1)
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"

--- a/ansible/ocs.yaml
+++ b/ansible/ocs.yaml
@@ -9,13 +9,14 @@
 
   tasks:
   - name: Provision storage nodes and install OCS
-    when: ocs_enabled == true and use_kni_ipi_virt == true
+    when: ocs_enabled == true
     block:
     - name: Install non-pip dependencies
       package:
         name: "{{ item }}"
         state: latest
       with_items:
+        - ipmitool
         - virt-install
 
     - name: Install pip dependencies
@@ -30,8 +31,8 @@
       shell: |
         virt-install --ram 32768 --vcpus 12 --os-variant rhel8.0 --cpu host-passthrough \
         --disk size={{ ocp_worker_disk }},pool=default,device=disk,bus=virtio,format=qcow2 --import --noautoconsole \
-        --vnc --network=bridge:provisioning,mac="52:54:00:82:68:6{{ item }}" \
-        --network=bridge:baremetal,mac="52:54:00:82:69:6{{ item }}" --name "{{ ocp_cluster_name}}-storage-{{ item }}" \
+        --vnc --network=bridge:{{ ocp_cluster_name}}pr,mac="52:54:00:82:68:6{{ item }}" \
+        --network=bridge:{{ ocp_cluster_name }}bm,mac="52:54:00:82:69:6{{ item }}" --name "{{ ocp_cluster_name}}-storage-{{ item }}" \
         --os-type=linux --events on_reboot=restart --boot hd,network --noreboot
       register: create_vms
       failed_when: create_vms.stderr != "" and "is in use by another virtual machine" not in create_vms.stderr
@@ -41,24 +42,46 @@
         - 2
 
     - name: Read host {{ ocs_device }} information
-      parted: device={{ ocs_device }} unit=MiB
+      parted: device={{ ocs_device }} unit=GiB
       register: device_info
 
-    - name: Create partitions on {{ ocs_device }}
-      shell: |
-        parted {{ ocs_device }} mkpart primary ext2 0% 10%;
-        parted {{ ocs_device }} mkpart primary ext2 10% 20%;
-        parted {{ ocs_device }} mkpart primary ext2 20% 30%;
-        parted {{ ocs_device }} mkpart extended 30% 100%;
-        parted {{ ocs_device }} mkpart logical ext2 40% 50%;
-        parted {{ ocs_device }} mkpart logical ext2 50% 60%;
-        parted {{ ocs_device }} mkpart logical ext2 60% 70%;
-        parted {{ ocs_device }} mkpart logical ext2 70% 80%;
-        parted {{ ocs_device }} mkpart logical ext2 80% 90%;
-        parted {{ ocs_device }} mkpart logical ext2 90% 100%
-      when: (device_info.partitions | length) == 0
+    - debug:
+        var: device_info
 
-    - name: attach disks to storage VMs
+    - name: Prepare partitions on {{ ocs_device }}
+      when: (device_info.partitions | length) == 0
+      block:
+        - name: Set msdos disk extended partition range end
+          set_fact:
+            extended_part_end: "100%"
+          when: device_info.disk.table == "msdos"
+
+        - name: Set non-msdos disk extended partition range end
+          set_fact:
+            extended_part_end: "40%"
+          when: device_info.disk.table != "msdos"
+
+        - name: Create partitions on {{ ocs_device }}
+          shell: |
+            parted {{ ocs_device }} mkpart primary ext2 0% 10%;
+            parted {{ ocs_device }} mkpart primary ext2 10% 20%;
+            parted {{ ocs_device }} mkpart primary ext2 20% 30%;
+            parted {{ ocs_device }} mkpart extended 30% {{ extended_part_end }};
+            parted {{ ocs_device }} mkpart logical ext2 40% 50%;
+            parted {{ ocs_device }} mkpart logical ext2 50% 60%;
+            parted {{ ocs_device }} mkpart logical ext2 60% 70%;
+            parted {{ ocs_device }} mkpart logical ext2 70% 80%;
+            parted {{ ocs_device }} mkpart logical ext2 80% 90%;
+            parted {{ ocs_device }} mkpart logical ext2 90% 100%
+
+    - name: Re-read host {{ ocs_device }} information
+      parted: device={{ ocs_device }} unit=GiB
+      register: device_info
+
+    - debug:
+        var: device_info
+
+    - name: Attach disks to storage VMs
       command: "{{ item }}"
       register: attach_disks
       failed_when: attach_disks.stderr != "" and "already exists" not in attach_disks.stderr
@@ -71,11 +94,20 @@
         - "virsh attach-disk {{ ocp_cluster_name }}-storage-1 --source {{ ocs_device }}7 --target vdd --persistent"
         - "virsh attach-disk {{ ocp_cluster_name }}-storage-2 --source {{ ocs_device }}8 --target vdb --persistent"
         - "virsh attach-disk {{ ocp_cluster_name }}-storage-2 --source {{ ocs_device }}9 --target vdc --persistent"
-        - "virsh attach-disk {{ ocp_cluster_name }}-storage-2 --source {{ ocs_device }}10 --target vdd --persistent"     
+        - "virsh attach-disk {{ ocp_cluster_name }}-storage-2 --source {{ ocs_device }}10 --target vdd --persistent"    
+
+    - name: Fixes for dev-scripts vbmc container
+      when: not use_kni_ipi_virt
+      block:
+      - name: Stop and remove vbmc container
+        shell: podman stop vbmc && podman rm vbmc
+
+      - name: Start vbmc container with proper mounts
+        shell: podman run -d --net host --privileged --name vbmc -v "{{ base_path }}/virtualbmc/vbmc":/root/.vbmc -v "/root/.ssh":/root/ssh -v "/var/run/libvirt:/var/run/libvirt:Z" quay.io/metal3-io/vbmc 
 
     - name: Create and start storage VM vbmcs
       shell: |
-        vbmc add "{{ ocp_cluster_name}}-storage-{{ item }}" --port "626{{ item }}" --username ADMIN --password ADMIN;
+        vbmc add "{{ ocp_cluster_name}}-storage-{{ item }}" --address 192.168.111.1 --port "626{{ item }}" --username ADMIN --password ADMIN;
         vbmc start "{{ ocp_cluster_name}}-storage-{{ item }}"
       with_items:
         - 0
@@ -87,7 +119,7 @@
         port: "626{{ item }}/udp"
         permanent: yes
         state: enabled
-        zone: "public"
+        zone: "{{ (use_kni_ipi_virt) | ternary('public','libvirt') }}"
         immediate: yes
       with_items:
         - 0
@@ -95,48 +127,84 @@
         - 2
     
     - name: Shutdown storage VMs using IPMI via vbmcs
-      shell: ipmitool -I lanplus -U ADMIN -P ADMIN -H 127.0.0.1 -p "626{{ item }}" power off
+      shell: ipmitool -I lanplus -U ADMIN -P ADMIN -H 192.168.111.1 -p "626{{ item }}" power off
       retries: 2
       with_items:
         - 0
         - 1
         - 2
 
-    - name: Add storage VM hostnames and IPs to DHCP server
-      blockinfile:
-        path: "{{ base_path }}/dev-scripts/dhcp/generated/bm/etc/dnsmasq.d/dnsmasq.hostsfile"
-        block: |
-          52:54:00:82:69:60,192.168.111.140,{{ ocp_cluster_name }}-storage-0.{{ ocp_cluster_name }}.test.metalkube.org
-          52:54:00:82:69:61,192.168.111.141,{{ ocp_cluster_name }}-storage-1.{{ ocp_cluster_name }}.test.metalkube.org
-          52:54:00:82:69:62,192.168.111.142,{{ ocp_cluster_name }}-storage-2.{{ ocp_cluster_name }}.test.metalkube.org
-    
-    - name: Restart DHCP server
+    - name: Prepare DNS/DHCP for storage VMs for dev-scripts environment
+      when: not use_kni_ipi_virt
       shell: |
-        podman stop ipi-dnsmasq-bm;
-        podman start ipi-dnsmasq-bm
+        virsh net-update {{ ocp_cluster_name }}bm add ip-dhcp-host "<host mac='52:54:00:82:69:6{{ item }}' name='storage-{{ item }}' ip='192.168.111.3{{ item }}' />" --live --config;
+        virsh net-update {{ ocp_cluster_name }}bm add dns-host "<host ip='192.168.111.3{{ item }}'><hostname>storage-{{ item }}</hostname></host>" --live --config
+      register: add_dhcp_dns_entries
+      failed_when: add_dhcp_dns_entries.stderr != "" and "there is an existing" not in add_dhcp_dns_entries.stderr
+      with_items:
+        - 0
+        - 1
+        - 2
 
-    - name: Add storage VM hostnames and IP octet to DNS server
-      blockinfile:
-        path: "{{ base_path }}/dev-scripts/dns/generated/db.reverse"
-        block: |
-          140 IN  PTR {{ ocp_cluster_name }}-storage-0.{{ ocp_cluster_name }}.test.metalkube.org.
-          141 IN  PTR {{ ocp_cluster_name }}-storage-1.{{ ocp_cluster_name }}.test.metalkube.org.
-          142 IN  PTR {{ ocp_cluster_name }}-storage-2.{{ ocp_cluster_name }}.test.metalkube.org.
+    - name: Prepare DNS/DHCP for storage VMs for kni-ipi-virt environment
+      when: use_kni_ipi_virt
+      block:
+      - name: Add storage VM hostnames and IPs to DHCP server
+        blockinfile:
+          path: "{{ base_path }}/dev-scripts/dhcp/generated/bm/etc/dnsmasq.d/dnsmasq.hostsfile"
+          block: |
+            52:54:00:82:69:60,192.168.111.140,{{ ocp_cluster_name }}-storage-0.{{ ocp_cluster_name }}.test.metalkube.org
+            52:54:00:82:69:61,192.168.111.141,{{ ocp_cluster_name }}-storage-1.{{ ocp_cluster_name }}.test.metalkube.org
+            52:54:00:82:69:62,192.168.111.142,{{ ocp_cluster_name }}-storage-2.{{ ocp_cluster_name }}.test.metalkube.org
+      
+      - name: Restart DHCP server
+        shell: |
+          podman stop ipi-dnsmasq-bm;
+          podman start ipi-dnsmasq-bm
 
-    - name: Add storage VM hostnames and IPs DNS server
-      blockinfile:
-        path: "{{ base_path }}/dev-scripts/dns/generated/db.zone"
-        block: |
-          {{ ocp_cluster_name }}-storage-0                          A 192.168.111.140
-          {{ ocp_cluster_name }}-storage-1                          A 192.168.111.141
-          {{ ocp_cluster_name }}-storage-2                          A 192.168.111.142
+      - name: Add storage VM hostnames and IP octet to DNS server
+        blockinfile:
+          path: "{{ base_path }}/dev-scripts/dns/generated/db.reverse"
+          block: |
+            140 IN  PTR {{ ocp_cluster_name }}-storage-0.{{ ocp_cluster_name }}.test.metalkube.org.
+            141 IN  PTR {{ ocp_cluster_name }}-storage-1.{{ ocp_cluster_name }}.test.metalkube.org.
+            142 IN  PTR {{ ocp_cluster_name }}-storage-2.{{ ocp_cluster_name }}.test.metalkube.org.
 
-    - name: Restart DNS server
-      shell: |
-        podman stop ipi-coredns;
-        podman start ipi-coredns
-      become: yes
-      become_user: ocp
+      - name: Add storage VM hostnames and IPs DNS server
+        blockinfile:
+          path: "{{ base_path }}/dev-scripts/dns/generated/db.zone"
+          block: |
+            {{ ocp_cluster_name }}-storage-0                          A 192.168.111.140
+            {{ ocp_cluster_name }}-storage-1                          A 192.168.111.141
+            {{ ocp_cluster_name }}-storage-2                          A 192.168.111.142
+
+      - name: Restart DNS server
+        shell: |
+          podman stop ipi-coredns;
+          podman start ipi-coredns
+        become: yes
+        become_user: ocp
+
+    # - name: Get RHCOS image URL used for workers
+    #   shell: "oc get machineset/{{ ocp_cluster_name }}-worker-0 -n openshift-machine-api -o json | jq -r '.spec.template.spec.providerSpec.value.image.url'"
+    #   register: rhcos_image_url
+    #   environment:
+    #     PATH: "{{ oc_env_path }}"
+    #     KUBECONFIG: "{{ kubeconfig }}"
+
+    # - name: Get RHCOS image checksum used for workers
+    #   shell: "oc get machineset/{{ ocp_cluster_name }}-worker-0 -n openshift-machine-api -o json | jq -r '.spec.template.spec.providerSpec.value.image.checksum'"
+    #   register: rhcos_image_checksum
+    #   environment:
+    #     PATH: "{{ oc_env_path }}"
+    #     KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Get existing {{ ocp_cluster_name }} worker machineset JSON
+      shell: "oc get machineset/{{ ocp_cluster_name }}-worker-0 -n openshift-machine-api -o json"
+      register: worker_ms_json
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
 
     - name: Create OCS YAMLs working dir
       file:
@@ -175,7 +243,7 @@
       retries: 100
       delay: 30
       register: storage_bmhs_ready
-      until: (storage_bmhs_ready.stdout | regex_findall('OK       ready') | length) == 3
+      until: (storage_bmhs_ready.stdout | regex_findall('OK       ready') | length) == 3 or (storage_bmhs_ready.stdout | regex_findall('OK       provisioned') | length) == 3
       environment:
         PATH: "{{ oc_env_path }}"
         KUBECONFIG: "{{ kubeconfig }}"
@@ -237,6 +305,9 @@
       delay: 20
       register: local_storage_volumes_ready
       until: (local_storage_volumes_ready.stdout | regex_findall('local-pv-.+Available') | length) == (local_storage_volumes_ready.stdout | regex_findall('local-pv-.+') | length) and (local_storage_volumes_ready.stdout | regex_findall('local-pv-.+Available') | length) != 0
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
 
     - name: Deploy OCS subscription
       shell: oc apply -f {{ working_yamls_dir }}/ocs/ocs-sub.yaml

--- a/ansible/ocs_cleanup.yaml
+++ b/ansible/ocs_cleanup.yaml
@@ -9,12 +9,21 @@
 
   tasks:
   - name: Remove OCS and de-provision storage nodes
-    when: ocs_enabled == true and use_kni_ipi_virt == true
+    when: ocs_enabled == true
     block:
     - name: Delete OCS storage cluster object
       shell: oc delete --ignore-not-found -f {{ working_yamls_dir }}/ocs/ocs-storage-cluster.yaml
       register: remove_ocs_storage_cluster
       failed_when: remove_ocs_storage_cluster.stderr != "" and ("not found" not in remove_ocs_storage_cluster.stderr and "no matches for kind" not in remove_ocs_storage_cluster.stderr)
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Make sure OCS ceph-cluster deployments are deleted
+      shell: |
+        for i in $(oc get deployment -n openshift-storage -l app=rook-ceph-osd --no-headers -o name); do 
+          oc delete deployment/$i -n openshift-storage; 
+          done
       environment:
         PATH: "{{ oc_env_path }}"
         KUBECONFIG: "{{ kubeconfig }}"

--- a/ansible/ocs_cleanup.yaml
+++ b/ansible/ocs_cleanup.yaml
@@ -1,0 +1,173 @@
+---
+- hosts: convergence_base
+  gather_facts: false
+  become: true
+  user: root
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+
+  tasks:
+  - name: Remove OCS and de-provision storage nodes
+    when: ocs_enabled == true and use_kni_ipi_virt == true
+    block:
+    - name: Delete OCS storage cluster object
+      shell: oc delete --ignore-not-found -f {{ working_yamls_dir }}/ocs/ocs-storage-cluster.yaml
+      register: remove_ocs_storage_cluster
+      failed_when: remove_ocs_storage_cluster.stderr != "" and ("not found" not in remove_ocs_storage_cluster.stderr and "no matches for kind" not in remove_ocs_storage_cluster.stderr)
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Wait until rook-ceph-mon, rook-ceph-osd and non-operator-noobaa pods are removed
+      shell: oc get pods -n openshift-storage
+      retries: 100
+      delay: 15
+      register: ocs_pods_removed
+      until: (ocs_pods_removed.stdout | regex_findall('rook-ceph-mon-') | length) == 0 and (ocs_pods_removed.stdout | regex_findall('rook-ceph-osd-') | length) == 0
+             and (ocs_pods_removed.stdout | regex_findall('noobaa-') | length) <= 1
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+    
+    - name: Delete OCS subscription
+      shell: oc delete --ignore-not-found -f {{ working_yamls_dir }}/ocs/ocs-sub.yaml
+      register: remove_ocs_sub
+      failed_when: remove_ocs_sub.stderr != "" and ("not found" not in remove_ocs_sub.stderr and "no matches for kind" not in remove_ocs_sub.stderr)
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Wait until openshift-storage namespace is removed
+      shell: oc get namespace
+      retries: 100
+      delay: 15
+      register: ocs_namespace_removed
+      until: (ocs_namespace_removed.stdout | regex_findall('openshift-storage') | length) == 0
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Delete local-storage localvolume objects
+      shell: oc delete --ignore-not-found -f {{ working_yamls_dir }}/ocs/local-storage-volumes.yaml
+      register: remove_local_storage_volumes
+      failed_when: remove_local_storage_volumes.stderr != "" and ("not found" not in remove_local_storage_volumes.stderr and "no matches for kind" not in remove_local_storage_volumes.stderr)
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Delete local-storage pvs
+      shell: |
+        for i in $(oc get pv -n local-storage -l storage.openshift.com/local-volume-owner-name=local-disks --no-headers -o name); do
+          oc delete $i
+        done
+      register: remove_local_storage_pvs
+      failed_when: remove_local_storage_pvs.stderr != "" and "not found" not in remove_local_storage_pvs.stderr
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"      
+
+    - name: Delete local-storage subscription
+      shell: oc delete --ignore-not-found -f {{ working_yamls_dir }}/ocs/local-storage-sub.yaml
+      register: remove_local_storage_sub
+      failed_when: remove_local_storage_sub.stderr != "" and ("not found" not in remove_local_storage_sub.stderr and "no matches for kind" not in remove_local_storage_sub.stderr)
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Wait until local-storage namespace is removed
+      shell: oc get namespace
+      retries: 100
+      delay: 15
+      register: local_storage_namespace_removed
+      until: (local_storage_namespace_removed.stdout | regex_findall('local-storage') | length) == 0
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Scale storage machineset to 0
+      shell: oc scale machineset/{{ ocp_cluster_name }}-storage-0 --replicas=0 -n openshift-machine-api
+      register: scale_machineset
+      failed_when: scale_machineset.stderr != "" and "not found" not in scale_machineset.stderr
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Wait for storage nodes to be de-provisioned
+      shell: oc get nodes -l node-role.kubernetes.io/storage
+      retries: 100
+      delay: 30
+      register: storage_nodes_removed
+      until: "'-storage-' not in storage_nodes_removed.stdout"
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Delete storage machineset
+      shell: oc delete --ignore-not-found machineset/{{ ocp_cluster_name }}-storage-0 -n openshift-machine-api
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Remove storage baremetal hosts from OCP
+      shell: oc delete --ignore-not-found bmh/storage-{{ item }} -n openshift-machine-api
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+      with_items:
+        - 0
+        - 1
+        - 2
+
+    - name: Stop and delete storage VM vbmcs
+      shell: |
+        vbmc stop {{ item }};
+        vbmc delete {{ item }}
+      register: remove_vbmcs
+      failed_when: remove_vbmcs.stderr != "" and "No domain with matching name" not in remove_vbmcs.stderr
+      with_items:
+        - "{{ ocp_cluster_name }}-storage-0"
+        - "{{ ocp_cluster_name }}-storage-1"
+        - "{{ ocp_cluster_name }}-storage-2"
+
+    - name: Destroy and undefine storage VMs
+      shell: |
+        virsh destroy {{ item }};
+        virsh undefine {{ item }}
+      register: remove_vms
+      failed_when: remove_vms.stderr != "" and ("failed to get domain" not in remove_vms.stderr and "domain is not running" not in remove_vms.stderr)
+      with_items:
+        - "{{ ocp_cluster_name }}-storage-0"
+        - "{{ ocp_cluster_name }}-storage-1"
+        - "{{ ocp_cluster_name }}-storage-2"
+      
+    - name: Remove storage VM qcow2s
+      command: "virsh vol-delete {{ item }}.qcow2 --pool=default"
+      register: remove_vm_volumes
+      failed_when: remove_vm_volumes.stderr != "" and "Storage volume not found" not in remove_vm_volumes.stderr
+      with_items:
+        - "{{ ocp_cluster_name }}-storage-0"
+        - "{{ ocp_cluster_name }}-storage-1"
+        - "{{ ocp_cluster_name }}-storage-2"
+
+    - name: Get list of lingering OCS VGs, if any
+      shell: |
+        vgs --noheadings -o vg_name
+      register: ocs_vgs
+
+    - name: Delete lingering OCS VGs, if any
+      command: vgremove {{ item }} -y
+      with_items: "{{ ocs_vgs.stdout_lines }}"
+      when:
+        - (item | regex_findall('ceph-') | length) > 0
+
+    - name: Read host {{ ocs_device }} information
+      parted: device={{ ocs_device }} unit=MiB
+      register: device_info
+
+    - name: Remove partitions on host {{ ocs_device }}
+      parted:
+        device: '{{ ocs_device }}'
+        number: '{{ item.num }}'
+        state: absent
+      loop: '{{ device_info.partitions }}'

--- a/ansible/roles/nfs_server/tasks/main.yaml
+++ b/ansible/roles/nfs_server/tasks/main.yaml
@@ -11,13 +11,13 @@
 
 - name: open nfsv4 port 2049/tcp (permanent config)
   firewalld:
-    zone: libvirt
+    zone: "{{ (use_kni_ipi_virt) | ternary('public','libvirt') }}"
     port: 2049/tcp
     permanent: yes
     state: enabled
 
 - name: open nfsv4 port 2049/tcp (running config)
   firewalld:
-    zone: libvirt
+    zone: "{{ (use_kni_ipi_virt) | ternary('public','libvirt') }}"
     port: 2049/tcp
     state: enabled

--- a/ansible/templates/ocs/bmhs.yaml.j2
+++ b/ansible/templates/ocs/bmhs.yaml.j2
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storage-0-bmc-secret
+type: Opaque
+data:
+  username: QURNSU4=
+  password: QURNSU4=
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: storage-0
+  labels:
+    test-storage: "yes"
+spec:
+  online: true
+  bootMACAddress: 52:54:00:82:68:60 
+  bmc:
+    address: ipmi://192.168.111.1:6260
+    credentialsName: storage-0-bmc-secret 
+  hardwareProfile: libvirt
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storage-1-bmc-secret
+type: Opaque
+data:
+  username: QURNSU4=
+  password: QURNSU4=
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: storage-1
+  labels:
+    test-storage: "yes"
+spec:
+  online: true
+  bootMACAddress: 52:54:00:82:68:61 
+  bmc:
+    address: ipmi://192.168.111.1:6261
+    credentialsName: storage-1-bmc-secret 
+  hardwareProfile: libvirt
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storage-2-bmc-secret
+type: Opaque
+data:
+  username: QURNSU4=
+  password: QURNSU4=
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: storage-2
+  labels:
+    test-storage: "yes"
+spec:
+  online: true
+  bootMACAddress: 52:54:00:82:68:62 
+  bmc:
+    address: ipmi://192.168.111.1:6262
+    credentialsName: storage-2-bmc-secret 
+  hardwareProfile: libvirt

--- a/ansible/templates/ocs/local-storage-sub.yaml.j2
+++ b/ansible/templates/ocs/local-storage-sub.yaml.j2
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-storage
+---
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: local-operator-group
+  namespace: local-storage
+spec:
+  targetNamespaces:
+    - local-storage
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: local-storage-operator
+  namespace: local-storage
+spec:
+  channel: "4.3"
+  installPlanApproval: Automatic
+  name: local-storage-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/ansible/templates/ocs/local-storage-volumes.yaml.j2
+++ b/ansible/templates/ocs/local-storage-volumes.yaml.j2
@@ -1,0 +1,22 @@
+apiVersion: local.storage.openshift.io/v1
+kind: LocalVolume
+metadata:
+  name: local-disks
+  namespace: local-storage
+spec:
+  logLevel: Normal
+  managementState: Managed
+  nodeSelector:
+    nodeSelectorTerms:
+      - matchExpressions:
+          - key: cluster.ocs.openshift.io/openshift-storage
+            operator: In
+            values:
+              - '' 
+  storageClassDevices:
+  - devicePaths:
+    - /dev/vdb
+    - /dev/vdc
+    - /dev/vdd
+    storageClassName: localblock-sc
+    volumeMode: Block

--- a/ansible/templates/ocs/machineset.yaml.j2
+++ b/ansible/templates/ocs/machineset.yaml.j2
@@ -1,0 +1,35 @@
+---
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: {{ ocp_cluster_name }} 
+  name: {{ ocp_cluster_name }}-storage-0
+  namespace: openshift-machine-api
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: {{ ocp_cluster_name }} 
+      machine.openshift.io/cluster-api-machineset: {{ ocp_cluster_name }}-storage-0
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: {{ ocp_cluster_name }} 
+        machine.openshift.io/cluster-api-machine-role: storage
+        machine.openshift.io/cluster-api-machine-type: storage
+        machine.openshift.io/cluster-api-machineset: {{ ocp_cluster_name }}-storage-0
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/storage: ""
+      providerSpec:
+        value:
+          hostSelector:
+            matchLabels:
+              test-storage: "yes"
+          image:
+            checksum: http://172.22.0.3:6180/images/rhcos-45.82.202008010929-0-openstack.x86_64.qcow2/rhcos-45.82.202008010929-0-compressed.x86_64.qcow2.md5sum
+            url: http://172.22.0.3:6180/images/rhcos-45.82.202008010929-0-openstack.x86_64.qcow2/rhcos-45.82.202008010929-0-compressed.x86_64.qcow2
+          userData:
+            name: worker-user-data

--- a/ansible/templates/ocs/machineset.yaml.j2
+++ b/ansible/templates/ocs/machineset.yaml.j2
@@ -29,7 +29,7 @@ spec:
             matchLabels:
               test-storage: "yes"
           image:
-            checksum: http://172.22.0.3:6180/images/rhcos-45.82.202008010929-0-openstack.x86_64.qcow2/rhcos-45.82.202008010929-0-compressed.x86_64.qcow2.md5sum
-            url: http://172.22.0.3:6180/images/rhcos-45.82.202008010929-0-openstack.x86_64.qcow2/rhcos-45.82.202008010929-0-compressed.x86_64.qcow2
+            checksum: "{{ worker_ms_json.stdout | from_json | json_query('spec.template.spec.providerSpec.value.image.checksum') }}"
+            url: "{{ worker_ms_json.stdout | from_json | json_query('spec.template.spec.providerSpec.value.image.url') }}"
           userData:
             name: worker-user-data

--- a/ansible/templates/ocs/ocs-storage-cluster.yaml.j2
+++ b/ansible/templates/ocs/ocs-storage-cluster.yaml.j2
@@ -1,0 +1,27 @@
+
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  namespace: openshift-storage
+  name: storagecluster
+spec:
+  manageNodes: false
+  monDataDirHostPath: /var/lib/rook
+  storageDeviceSets:
+    - name: deviceset-0
+      count: 3
+      replica: 3
+      resources:
+         requests: {}
+         limits: {}
+      placement: {}
+      dataPVCTemplate:
+        spec:
+          storageClassName: localblock-sc
+          accessModes:
+            - ReadWriteOnce
+          volumeMode: Block
+          resources:
+            requests:
+              storage: 180Gi
+      portable: false

--- a/ansible/templates/ocs/ocs-storage-cluster.yaml.j2
+++ b/ansible/templates/ocs/ocs-storage-cluster.yaml.j2
@@ -23,5 +23,5 @@ spec:
           volumeMode: Block
           resources:
             requests:
-              storage: 180Gi
+              storage: "{{ device_info.partitions[0].size | int}}Gi"
       portable: false

--- a/ansible/templates/ocs/ocs-sub.yaml.j2
+++ b/ansible/templates/ocs/ocs-sub.yaml.j2
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-storage
+spec: {}
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-storage-operatorgroup
+  namespace: openshift-storage
+spec:
+  serviceAccount:
+    metadata:
+      creationTimestamp: null
+  targetNamespaces:
+  - openshift-storage
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ocs-subscription
+  namespace: openshift-storage
+spec:
+  channel: stable-4.4
+  name: ocs-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/ansible/vars/default.yaml
+++ b/ansible/vars/default.yaml
@@ -1,7 +1,12 @@
 ---
 base_path: /home/ocp
-#dev_scripts_repo: defaults to "https://github.com/openshift-metal3/dev-scripts.git"
+
+#skip_subscription: true # set to true if you set subscription configuration manually before using this tool
+
+# OCP deployment fields
+#dev_scripts_repo: https://github.com/redhat-nfvpe/kni-ipi-virt.git # defaults to "https://github.com/openshift-metal3/dev-scripts.git"
 #dev_scripts_branch: defaults to "HEAD"
+use_kni_ipi_virt: "{{ dev_scripts_repo is defined and (dev_scripts_repo | regex_findall('kni-ipi-virt') | length) > 0 }}"
 
 # To set a specific release to install.
 ocp_release_image: quay.io/openshift-release-dev/ocp-release:4.5.8-x86_64
@@ -41,6 +46,9 @@ ocp_worker_disk: 120
 
 # OCP cluster name
 ocp_cluster_name: ostest
+
+# Kubeconfig default path
+kubeconfig_path: "{{ base_path }}/dev-scripts/ocp/{{ ocp_cluster_name }}/auth/kubeconfig"
 
 # Released version of the opm package from the operator-framework
 opm_version: v1.12.5
@@ -87,4 +95,8 @@ default_timeout: 180
 
 # worker node where openstackclient pod will run
 openstackclient_pod_worker: worker-0
+
+# ocs specific
+ocs_enabled: true   # NOTE: requires use_kni_ipi_virt to be true
+ocs_device: /dev/sdb
 


### PR DESCRIPTION
Enables:

1. Deploying with [kni-ipi-virt](https://github.com/redhat-nfvpe/kni-ipi-virt) instead of Metal3 dev-scripts.  The default is still dev-scripts.
2. Deploying OCS if using kni-ipi-virt