### PR TITLE
Fix incorrect placement keystone password in nova.conf

### DIFF
--- a/ansible/files/ocp/nova-api/2/configmap.yaml
+++ b/ansible/files/ocp/nova-api/2/configmap.yaml
@@ -129,7 +129,7 @@ data:
     user_domain_name = Default
     auth_url = http://keystone.openstack.svc:5000/
     username = placement
-    password = foobar123
+    password = openstack
 
     [scheduler]
     # run periodic task to discover hosts automatically


### PR DESCRIPTION
This was a regression from 2b177d65ea19791f6280bd8a910f2bc3a0857af4