### PR TITLE
Set personal pull-secret for dev-scripts

### DIFF
--- a/ansible/03_ocp_dev_scripts_prep.yaml
+++ b/ansible/03_ocp_dev_scripts_prep.yaml
@@ -106,12 +106,6 @@
         dest: "{{ secrets_repo_path }}"
         version: "{{ secrets_branch | default('HEAD', true) }}"
 
-  - name: set PULL_SECRET_FILE in {{ base_path }}/dev-scripts/config_$USER.sh
-    lineinfile:
-      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
-      regexp: '^export PULL_SECRET_FILE='
-      line: export PULL_SECRET_FILE="{{ secrets_repo_path }}/pull-secret"
-
   - name: set PERSONAL_PULL_SECRET in {{ base_path }}/dev-scripts/config_$USER.sh
     lineinfile:
       path: "{{ base_path }}/dev-scripts/config_$USER.sh"

--- a/ansible/03_ocp_dev_scripts_prep.yaml
+++ b/ansible/03_ocp_dev_scripts_prep.yaml
@@ -111,6 +111,12 @@
       path: "{{ base_path }}/dev-scripts/config_$USER.sh"
       regexp: '^export PULL_SECRET_FILE='
       line: export PULL_SECRET_FILE="{{ secrets_repo_path }}/pull-secret"
+
+  - name: set PERSONAL_PULL_SECRET in {{ base_path }}/dev-scripts/config_$USER.sh
+    lineinfile:
+      path: "{{ base_path }}/dev-scripts/config_$USER.sh"
+      regexp: '^export PERSONAL_PULL_SECRET='
+      line: export PERSONAL_PULL_SECRET="{{ secrets_repo_path }}/pull-secret"
     
   - name: set CI_TOKEN in {{ base_path }}/dev-scripts/config_$USER.sh
     lineinfile:


### PR DESCRIPTION
We also need to set `PERSONAL_PULL_SECRET` to the path of our pull-secret to make dev-scripts happy