### PR TITLE
Init env vars in install_ctlplane.yaml

### DIFF
--- a/ansible/install_ctlplane.yaml
+++ b/ansible/install_ctlplane.yaml
@@ -28,7 +28,8 @@
       set -e
       oc apply -n openstack -f "{{ ctlplane_yaml_dir }}"
     environment: &oc_env
-      <<: *oc_env
+      PATH: "{{ oc_env_path }}"
+      KUBECONFIG: "{{ kubeconfig }}"
 
   - name: Wait for mariadb pod creation
     shell: |


### PR DESCRIPTION
If you create a dev environment from scratch (i.e. provision a new DSAL and eventually `make`), the `make ctlplane` fails with the following error:

```
TASK [Start ctlplane] **********************************************************************************************************************************************************************************************************************************************************************
Monday 05 October 2020  12:34:04 +0000 (0:00:00.615)       0:00:13.998 ********
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "set -e\noc apply -n openstack -f \"/root/ostest-working/yamls/ctlplane\"\n", "delta": "0:00:00.110813", "end": "2020-10-05 12:34:04.920117", "msg": "non-zero return code", "rc": 1, "start": "2020-10-05 12:34:04.809304", "stderr": "error: Missing or incomplete configuration info.  Please point to an existing, complete config file:\n\n\n  1. Via the command-line flag --kubeconfig\n  2. Via the KUBECONFIG environment variable\n  3. In your home directory as ~/.kube/config\n\nTo view or setup config directly use the 'config' command.", "stderr_lines": ["error: Missing or incomplete configuration info.  Please point to an existing, complete config file:", "", "", "  1. Via the command-line flag --kubeconfig", "  2. Via the KUBECONFIG environment variable", "  3. In your home directory as ~/.kube/config", "", "To view or setup config directly use the 'config' command."], "stdout": "", "stdout_lines": []}
```

Initializing the `environment` block at the top of the file affected here seems to fix the issue.