### PR TITLE
Remove obsolete 06_osp_storage.yaml

### DIFF
--- a/ansible/06_osp_storage.yaml
+++ b/ansible/06_osp_storage.yaml
@@ -1,9 +1,0 @@
----
-- hosts: localhost
-  gather_facts: false
-  vars_files: vars/default.yaml
-  tasks:
-    - block:
-        - name: Provision and install OCS storage
-          include: ocs.yaml
-      when: ocs_enabled == true


### PR DESCRIPTION
This playbook is no longer referenced, and doesn't work.