### PR TITLE
Workaround for perf/sriov operator install

### DIFF
--- a/ansible/Makefile
+++ b/ansible/Makefile
@@ -35,7 +35,8 @@ post_install: hosts local-defaults.yaml
 	04_local_oc_client.yaml \
 	05_default_storageclass.yaml \
 	ocp_image_registry.yaml \
-	11_setup_extra_nics_on_vms.yaml
+	11_setup_extra_nics_on_vms.yaml \
+	perf_sriov.yaml
 
 osp_operators_install: compute_node
 compute_node: hosts local-defaults.yaml

--- a/ansible/perf_sriov.yaml
+++ b/ansible/perf_sriov.yaml
@@ -1,0 +1,55 @@
+---
+- hosts: localhost
+  gather_facts: false
+  become: true
+  user: root
+  vars_files: vars/default.yaml
+  roles:
+  - oc_local
+  tasks:    
+    - name: Create performance and sriov YAMLs working dir
+      file:
+        path: "{{ working_yamls_dir }}/{{ item }}"
+        state: directory
+        mode: 0755
+      with_items:
+        - performance
+        - sriov
+
+    - name: Write performance and sriov YAMLs to working dir
+      template:
+        src: "{{ item }}/{{ item }}-sub.yaml.j2"
+        dest: "{{ working_yamls_dir }}/{{ item }}/{{ item }}-sub.yaml"
+      with_items:
+        - performance
+        - sriov
+
+    - name: Apply performance and sriov YAMLs
+      shell: "oc apply -f {{ working_yamls_dir }}/{{ item }}/{{ item }}-sub.yaml"
+      with_items:
+        - performance
+        - sriov
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+
+    - name: Wait for the performance operator to become available
+      shell: oc wait deployment/performance-operator --for condition=Available -n openshift-performance-addon --timeout="{{ default_timeout }}s"
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+      register: performance_op_ready
+      until: performance_op_ready is not failed and performance_op_ready.stdout == 'deployment.apps/performance-operator condition met'
+      retries: "{{ (default_timeout / 5)|int }}"
+      delay: 5
+
+    - name: Wait for the sriov operator to become available
+      shell: oc wait deployment/sriov-network-operator --for condition=Available -n openshift-sriov-network-operator --timeout="{{ default_timeout }}s"
+      environment:
+        PATH: "{{ oc_env_path }}"
+        KUBECONFIG: "{{ kubeconfig }}"
+      register: sriov_op_ready
+      until: sriov_op_ready is not failed and sriov_op_ready.stdout == 'deployment.apps/sriov-network-operator condition met'
+      retries: "{{ (default_timeout / 5)|int }}"
+      delay: 5
+        

--- a/ansible/templates/performance/performance-sub.yaml.j2
+++ b/ansible/templates/performance/performance-sub.yaml.j2
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-performance-addon
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-performance-addon-operatorgroup
+  namespace: openshift-performance-addon
+spec:
+  targetNamespaces:
+  - openshift-performance-addon
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: performance-addon-operator-subscription
+  namespace: openshift-performance-addon
+spec:
+  channel: "4.5"
+  name: performance-addon-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/ansible/templates/sriov/sriov-sub.yaml.j2
+++ b/ansible/templates/sriov/sriov-sub.yaml.j2
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-sriov-network-operator
+  labels:
+    openshift.io/run-level: "1"
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: sriov-network-operators
+  namespace: openshift-sriov-network-operator
+spec:
+  targetNamespaces:
+  - openshift-sriov-network-operator
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sriov-network-operator-subscription
+  namespace: openshift-sriov-network-operator
+spec:
+  channel: "4.5"
+  name: sriov-network-operator
+  source: redhat-operators 
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Temporary means by which to install performance and SRIOV operators until we get them working via OLM