### PR TITLE
perf_srio: Don't run as root

### DIFF
--- a/ansible/perf_sriov.yaml
+++ b/ansible/perf_sriov.yaml
@@ -1,8 +1,6 @@
 ---
 - hosts: localhost
   gather_facts: false
-  become: true
-  user: root
   vars_files: vars/default.yaml
   roles:
   - oc_local


### PR DESCRIPTION
oc_local jobs run as the default user. This will only work if the default user
is root.